### PR TITLE
Localize GPT chat hint

### DIFF
--- a/feature/gpt/src/main/res/layout/activity_default_messages.xml
+++ b/feature/gpt/src/main/res/layout/activity_default_messages.xml
@@ -51,7 +51,7 @@
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
       android:layout_alignParentBottom="true"
-      app:inputHint="send"
+      app:inputHint="@string/message_input_hint"
       app:inputButtonHeight="48dp"
       app:inputButtonWidth="48dp"
       app:inputButtonDefaultBgColor="@color/accent_color_dark"

--- a/feature/gpt/src/main/res/values-ar/strings.xml
+++ b/feature/gpt/src/main/res/values-ar/strings.xml
@@ -35,5 +35,6 @@
   <string name="upgrade_now">ابدأ فترة تجريبية مجانية لمدة 7 أيام</string>
   <string name="no_thanks">ربما لاحقًا</string>
   <string name="trial_conditions">• يمكنك الإلغاء في أي وقت\n• لا رسوم أثناء الفترة التجريبية المجانية\n• ميزات حصرية أثناء التجربة</string>
+  <string name="message_input_hint">اكتب رسالتك</string>
 
 </resources>

--- a/feature/gpt/src/main/res/values-az/strings.xml
+++ b/feature/gpt/src/main/res/values-az/strings.xml
@@ -35,5 +35,6 @@
   <string name="upgrade_now">7 günlük pulsuz sınağa başlayın</string>
   <string name="no_thanks">Bəlkə sonra</string>
   <string name="trial_conditions">• İstənilən vaxt ləğv edin\n• Pulsuz sınaq dövründə heç bir ödəniş olmayacaq\n• Sınaq müddətində eksklüziv funksiyalar</string>
+  <string name="message_input_hint">Mesajınızı yazın</string>
 
 </resources>

--- a/feature/gpt/src/main/res/values-bs/strings.xml
+++ b/feature/gpt/src/main/res/values-bs/strings.xml
@@ -36,5 +36,6 @@
   <string name="upgrade_now">Započnite 7-dnevno besplatno probno razdoblje</string>
   <string name="no_thanks">Možda kasnije</string>
   <string name="trial_conditions">• Možete otkazati u bilo kojem trenutku\n• Nema troškova tokom besplatnog probnog perioda\n• Ekskluzivne funkcije tokom probnog perioda</string>
+  <string name="message_input_hint">Unesite poruku</string>
 
 </resources>

--- a/feature/gpt/src/main/res/values-de/strings.xml
+++ b/feature/gpt/src/main/res/values-de/strings.xml
@@ -35,5 +35,6 @@
   <string name="upgrade_now">Starten Sie die 7-tägige kostenlose Testversion</string>
   <string name="no_thanks">Vielleicht später</string>
   <string name="trial_conditions">• Jederzeit kündbar\n• Keine Kosten während der Testphase\n• Exklusive Funktionen während des Tests</string>
+  <string name="message_input_hint">Nachricht eingeben</string>
 
 </resources>

--- a/feature/gpt/src/main/res/values-es/strings.xml
+++ b/feature/gpt/src/main/res/values-es/strings.xml
@@ -36,5 +36,6 @@
   <string name="upgrade_now">Comienza la prueba gratuita de 7 días</string>
   <string name="no_thanks">Tal vez más tarde</string>
   <string name="trial_conditions">• Cancela en cualquier momento\n• Sin cargos durante el periodo de prueba gratuito\n• Funciones exclusivas durante la prueba</string>
+  <string name="message_input_hint">Escribe tu mensaje</string>
 
 </resources>

--- a/feature/gpt/src/main/res/values-fa/strings.xml
+++ b/feature/gpt/src/main/res/values-fa/strings.xml
@@ -36,5 +36,6 @@
   <string name="upgrade_now">آغاز آزمایش رایگان 7 روزه</string>
   <string name="no_thanks">شاید بعداً</string>
   <string name="trial_conditions">• امکان لغو در هر زمان\n• بدون هزینه در طول دوره آزمایشی رایگان\n• ویژگی‌های انحصاری در طول دوره آزمایشی</string>
+  <string name="message_input_hint">پیام خود را بنویسید</string>
 
 </resources>

--- a/feature/gpt/src/main/res/values-fr/strings.xml
+++ b/feature/gpt/src/main/res/values-fr/strings.xml
@@ -36,5 +36,6 @@
   <string name="upgrade_now">Commencez l\'essai gratuit de 7 jours</string>
   <string name="no_thanks">Peut-être plus tard</string>
   <string name="trial_conditions">• Annulez à tout moment\n• Aucun frais pendant la période d\'essai gratuite\n• Fonctionnalités exclusives pendant l\'essai</string>
+  <string name="message_input_hint">Écrivez votre message</string>
 
 </resources>

--- a/feature/gpt/src/main/res/values-hr/strings.xml
+++ b/feature/gpt/src/main/res/values-hr/strings.xml
@@ -36,5 +36,6 @@
   <string name="upgrade_now">Započnite besplatnu probnu verziju od 7 dana</string>
   <string name="no_thanks">Možda kasnije</string>
   <string name="trial_conditions">• Otkazivanje u bilo kojem trenutku\n• Nema troškova tijekom besplatnog probnog razdoblja\n• Ekskluzivne značajke tijekom probnog razdoblja</string>
+  <string name="message_input_hint">Upišite poruku</string>
 
 </resources>

--- a/feature/gpt/src/main/res/values-hu/strings.xml
+++ b/feature/gpt/src/main/res/values-hu/strings.xml
@@ -36,5 +36,6 @@
   <string name="upgrade_now">Kezdje el a 7 napos ingyenes próbát</string>
   <string name="no_thanks">Lehet, hogy később</string>
   <string name="trial_conditions">• Bármikor lemondható\n• Ingyenes próbaidőszak alatt nincs díj\n• Exkluzív funkciók a próbaidőszak alatt</string>
+  <string name="message_input_hint">Írja be üzenetét</string>
 
 </resources>

--- a/feature/gpt/src/main/res/values-in/strings.xml
+++ b/feature/gpt/src/main/res/values-in/strings.xml
@@ -35,5 +35,6 @@
   <string name="upgrade_now">Mulai uji coba gratis 7 hari</string>
   <string name="no_thanks">Mungkin nanti</string>
   <string name="trial_conditions">• Batalkan kapan saja\n• Tidak ada biaya selama masa uji coba gratis\n• Fitur eksklusif selama masa uji coba</string>
+  <string name="message_input_hint">Ketik pesan Anda</string>
 
 </resources>

--- a/feature/gpt/src/main/res/values-it/strings.xml
+++ b/feature/gpt/src/main/res/values-it/strings.xml
@@ -36,5 +36,6 @@
   <string name="upgrade_now">Inizia la prova gratuita di 7 giorni</string>
   <string name="no_thanks">Forse più tardi</string>
   <string name="trial_conditions">• Annulla in qualsiasi momento\n• Nessun addebito durante il periodo di prova gratuito\n• Funzionalità esclusive durante la prova</string>
+  <string name="message_input_hint">Scrivi il tuo messaggio</string>
 
 </resources>

--- a/feature/gpt/src/main/res/values-kk/strings.xml
+++ b/feature/gpt/src/main/res/values-kk/strings.xml
@@ -35,5 +35,6 @@
   <string name="upgrade_now">7 күндік тегін сынақты бастаңыз</string>
   <string name="no_thanks">Мүмкін кейінірек</string>
   <string name="trial_conditions">• Кез келген уақытта бас тартуға болады\n• Тегін сынақ кезеңінде ешқандай төлем болмайды\n• Сынақ кезеңінде эксклюзивті мүмкіндіктер</string>
+  <string name="message_input_hint">Хабарламаңызды жазыңыз</string>
 
 </resources>

--- a/feature/gpt/src/main/res/values-ku/strings.xml
+++ b/feature/gpt/src/main/res/values-ku/strings.xml
@@ -36,5 +36,6 @@
   <string name="upgrade_now">سەرەتا 7 رۆژ بە بێتاکەوە دەست پێ بکە</string>
   <string name="no_thanks">لە کاتی تر</string>
   <string name="trial_conditions">• هەر کاتیش لەماوەدا ڕەت کردنەوە دەکرێت\n• هیچ تەرخانێکی نییە لە ماوەی تاقیکردنەوەی بێتاکەوە\n• تایبەتمەندیە تایبەتییەکان لە ماوەی تاقیکردنەوەدا</string>
+  <string name="message_input_hint">پەیامەکەت بنووسە</string>
 
 </resources>

--- a/feature/gpt/src/main/res/values-ms/strings.xml
+++ b/feature/gpt/src/main/res/values-ms/strings.xml
@@ -34,5 +34,6 @@
   <string name="upgrade_now">Mulakan percubaan percuma 7 hari</string>
   <string name="no_thanks">Mungkin kemudian</string>
   <string name="trial_conditions">• Boleh dibatalkan bila-bila masa\n• Tiada caj semasa percubaan percuma\n• Ciri eksklusif semasa percubaan</string>
+  <string name="message_input_hint">Taip mesej anda</string>
 
 </resources>

--- a/feature/gpt/src/main/res/values-nl/strings.xml
+++ b/feature/gpt/src/main/res/values-nl/strings.xml
@@ -35,5 +35,6 @@
   <string name="upgrade_now">Start de gratis proefperiode van 7 dagen</string>
   <string name="no_thanks">Misschien later</string>
   <string name="trial_conditions">• Annuleer op elk moment\n• Geen kosten tijdens de gratis proefperiode\n• Exclusieve functies tijdens de proefperiode</string>
+  <string name="message_input_hint">Typ je bericht</string>
 
 </resources>

--- a/feature/gpt/src/main/res/values-pl/strings.xml
+++ b/feature/gpt/src/main/res/values-pl/strings.xml
@@ -34,5 +34,6 @@
   <string name="upgrade_now">Rozpocznij 7-dniowy darmowy okres próbny</string>
   <string name="no_thanks">Może później</string>
   <string name="trial_conditions">• Anuluj w dowolnym momencie\n• Brak opłat podczas bezpłatnego okresu próbnego\n• Ekskluzywne funkcje podczas okresu próbnego</string>
+  <string name="message_input_hint">Wpisz wiadomość</string>
 
 </resources>

--- a/feature/gpt/src/main/res/values-pt/strings.xml
+++ b/feature/gpt/src/main/res/values-pt/strings.xml
@@ -35,5 +35,6 @@
   <string name="upgrade_now">Comece o teste gratuito de 7 dias</string>
   <string name="no_thanks">Talvez mais tarde</string>
   <string name="trial_conditions">• Cancele a qualquer momento\n• Sem cobranças durante o período de teste gratuito\n• Recursos exclusivos durante o teste</string>
+  <string name="message_input_hint">Digite sua mensagem</string>
 
 </resources>

--- a/feature/gpt/src/main/res/values-ru/strings.xml
+++ b/feature/gpt/src/main/res/values-ru/strings.xml
@@ -34,5 +34,6 @@
   <string name="upgrade_now">Начать 7-дневную бесплатную пробную версию</string>
   <string name="no_thanks">Может быть позже</string>
   <string name="trial_conditions">• Отменить в любой момент\n• Без оплаты во время бесплатного пробного периода\n• Эксклюзивные функции во время пробного периода</string>
+  <string name="message_input_hint">Введите сообщение</string>
 
 </resources>

--- a/feature/gpt/src/main/res/values-sq/strings.xml
+++ b/feature/gpt/src/main/res/values-sq/strings.xml
@@ -36,5 +36,6 @@
   <string name="upgrade_now">Fillo provën falas 7 ditore</string>
   <string name="no_thanks">Ndoshta më vonë</string>
   <string name="trial_conditions">• Anulo në çdo kohë\n• Pa pagesa gjatë periudhës së provës falas\n• Veçori ekskluzive gjatë provës</string>
+  <string name="message_input_hint">Shkruani mesazhin tuaj</string>
 
 </resources>

--- a/feature/gpt/src/main/res/values-sr/strings.xml
+++ b/feature/gpt/src/main/res/values-sr/strings.xml
@@ -36,5 +36,6 @@
   <string name="upgrade_now">Započnite 7-dnevno besplatno probno razdoblje</string>
   <string name="no_thanks">Možda kasnije</string>
   <string name="trial_conditions">• Otkažite u bilo kom trenutku\n• Nema troškova tokom besplatnog probnog perioda\n• Ekskluzivne funkcije tokom probnog perioda</string>
+  <string name="message_input_hint">Unesite poruku</string>
 
 </resources>

--- a/feature/gpt/src/main/res/values-sv/strings.xml
+++ b/feature/gpt/src/main/res/values-sv/strings.xml
@@ -36,5 +36,6 @@
   <string name="upgrade_now">Starta 7 dagars gratis provperiod</string>
   <string name="no_thanks">Kanske senare</string>
   <string name="trial_conditions">• Avbryt när som helst\n• Inga avgifter under gratis provperiod\n• Exklusiva funktioner under provperioden</string>
+  <string name="message_input_hint">Skriv ditt meddelande</string>
 
 </resources>

--- a/feature/gpt/src/main/res/values-th/strings.xml
+++ b/feature/gpt/src/main/res/values-th/strings.xml
@@ -36,5 +36,6 @@
   <string name="upgrade_now">เริ่มทดลองใช้ฟรี 7 วัน</string>
   <string name="no_thanks">อาจจะครั้งหน้า</string>
   <string name="trial_conditions">• ยกเลิกได้ทุกเมื่อ\n• ไม่มีค่าใช้จ่ายในช่วงทดลองใช้ฟรี\n• คุณสมบัติพิเศษระหว่างช่วงทดลอง</string>
+  <string name="message_input_hint">พิมพ์ข้อความของคุณ</string>
 
 </resources>

--- a/feature/gpt/src/main/res/values-tr/strings.xml
+++ b/feature/gpt/src/main/res/values-tr/strings.xml
@@ -34,5 +34,6 @@
   <string name="upgrade_now">7 günlük ücretsiz denemeye başlayın</string>
   <string name="no_thanks">Belki daha sonra</string>
   <string name="trial_conditions">• İstediğiniz zaman iptal edin\n• Ücretsiz deneme süresi boyunca hiçbir ücret yok\n• Deneme sırasında özel özellikler</string>
+  <string name="message_input_hint">Mesajınızı yazın</string>
 
 </resources>

--- a/feature/gpt/src/main/res/values-ug/strings.xml
+++ b/feature/gpt/src/main/res/values-ug/strings.xml
@@ -35,5 +35,6 @@
   <string name="upgrade_now">7 كۈنلۈك ھەقسىز سىناشنى باشلاڭ</string>
   <string name="no_thanks">بەلكى كېيىنچە</string>
   <string name="trial_conditions">• ھەر قانداق ۋاقىتتا بىكار قىلىش\n• ھەقسىز سىناش مەزگىلىدە ھەچقانداق ھەق تولانمايدۇ\n• سىناش مەزگىلىدە ئالاھىدە ئىقتىدارلار</string>
+  <string name="message_input_hint">ئۇچۇرىڭىزنى يېزىڭ</string>
 
 </resources>

--- a/feature/gpt/src/main/res/values-uk/strings.xml
+++ b/feature/gpt/src/main/res/values-uk/strings.xml
@@ -35,5 +35,6 @@
   <string name="upgrade_now">Розпочніть 7-денний безкоштовний пробний період</string>
   <string name="no_thanks">Можливо, пізніше</string>
   <string name="trial_conditions">• Скасуйте в будь-який час\n• Немає платежів під час безкоштовного пробного періоду\n• Ексклюзивні функції під час пробного періоду</string>
+  <string name="message_input_hint">Введіть повідомлення</string>
 
 </resources>

--- a/feature/gpt/src/main/res/values-uz/strings.xml
+++ b/feature/gpt/src/main/res/values-uz/strings.xml
@@ -34,5 +34,6 @@
   <string name="upgrade_now">7 kunlik bepul sinovni boshlang</string>
   <string name="no_thanks">Ehtimol, keyinroq</string>
   <string name="trial_conditions">• Istalgan vaqtda bekor qiling\n• Bepul sinov davrida hech qanday to‘lov yo‘q\n• Sinov davrida eksklyuziv xususiyatlar</string>
+  <string name="message_input_hint">Xabaringizni kiriting</string>
 
 </resources>

--- a/feature/gpt/src/main/res/values-vi/strings.xml
+++ b/feature/gpt/src/main/res/values-vi/strings.xml
@@ -35,5 +35,6 @@
   <string name="upgrade_now">Bắt đầu dùng thử miễn phí 7 ngày</string>
   <string name="no_thanks">Có thể sau</string>
   <string name="trial_conditions">• Hủy bất kỳ lúc nào\n• Không có phí trong thời gian dùng thử miễn phí\n• Tính năng độc quyền trong thời gian dùng thử</string>
+  <string name="message_input_hint">Nhập tin nhắn của bạn</string>
 
 </resources>

--- a/feature/gpt/src/main/res/values-zh/strings.xml
+++ b/feature/gpt/src/main/res/values-zh/strings.xml
@@ -34,5 +34,6 @@
   <string name="upgrade_now">开始 7 天免费试用</string>
   <string name="no_thanks">可能稍后</string>
   <string name="trial_conditions">• 随时取消\n• 免费试用期间无费用\n• 试用期间专属功能</string>
+  <string name="message_input_hint">输入您的消息</string>
 
 </resources>

--- a/feature/gpt/src/main/res/values/strings.xml
+++ b/feature/gpt/src/main/res/values/strings.xml
@@ -39,4 +39,5 @@ You\'ve reached your daily limit. Start your 3-day free trial for unlimited acce
   <string name="upgrade_now">Start 7 day free trial</string>
   <string name="no_thanks">Maybe later</string>
   <string name="trial_conditions">• Cancel anytime\n• No charges during free trial\n• Exclusive features during trial</string>
+  <string name="message_input_hint">Type your message</string>
 </resources>


### PR DESCRIPTION
## Summary
- localize MessageInput hint in GPT activity
- add translations for all supported languages

## Testing
- `./gradlew assembleMadaniDebug` *(fails: properties.getProperty("STORE_FILE") must not be null)*

------
https://chatgpt.com/codex/tasks/task_b_685407cefa10832a80c15e8e0d529e94