### PR TITLE
Enable Jetifier for AndroidX compatibility

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,6 +6,7 @@ org.gradle.caching=true
 org.gradle.configuration-cache.parallel=true
 
 android.useAndroidX=true
+android.enableJetifier=true
 android.disableAgpUpgradePrompt=true
 
 # kotlin 2.0


### PR DESCRIPTION
## Summary
- enable Jetifier so old support library dependencies translate to AndroidX

## Testing
- `./gradlew test` *(fails: Unrecognized VM option 'MaxPermSize=512m')*

------
https://chatgpt.com/codex/tasks/task_b_68b09a92ba44832ab3205f180fcd578d