### PR TITLE
feat(gpt): show ads in chat view for non-premium

### DIFF
--- a/feature/gpt/build.gradle.kts
+++ b/feature/gpt/build.gradle.kts
@@ -68,6 +68,8 @@ dependencies {
 
     implementation("com.android.billingclient:billing:7.0.0")
 
+    implementation("com.google.android.gms:play-services-ads:22.6.0")
+
 
     implementation(platform("com.google.firebase:firebase-bom:33.4.0"))
     implementation("com.google.firebase:firebase-analytics")

--- a/feature/gpt/src/main/java/com/appcoholic/gpt/BillingHelper.java
+++ b/feature/gpt/src/main/java/com/appcoholic/gpt/BillingHelper.java
@@ -71,7 +71,10 @@ public class BillingHelper {
   }
 
   private void startConnection() {
-    if (billingClient != null && !billingClient.isReady()) {
+    if (billingClient == null) {
+      setupBillingClient();
+    }
+    if (!billingClient.isReady()) {
       billingClient.startConnection(billingClientStateListener);
     }
   }
@@ -208,6 +211,7 @@ public class BillingHelper {
   public void endConnection() {
     if (billingClient != null) {
       billingClient.endConnection();
+      billingClient = null;
     }
   }
 }

--- a/feature/gpt/src/main/java/com/appcoholic/gpt/DefaultMessagesActivity.java
+++ b/feature/gpt/src/main/java/com/appcoholic/gpt/DefaultMessagesActivity.java
@@ -10,6 +10,8 @@ import android.os.Bundle;
 import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
+import android.view.View;
+import android.content.SharedPreferences;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
@@ -40,6 +42,8 @@ import com.stfalcon.chatkit.messages.MessageHolders;
 import com.stfalcon.chatkit.messages.MessageInput;
 import com.stfalcon.chatkit.messages.MessagesList;
 import com.stfalcon.chatkit.messages.MessagesListAdapter;
+import com.google.android.gms.ads.AdRequest;
+import com.google.android.gms.ads.AdView;
 
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -110,6 +114,8 @@ public class DefaultMessagesActivity extends AppCompatActivity
   private Toolbar toolbar;
 
   private MessageInput messageInput;  // Add this line
+  private AdView adView;
+  private SharedPreferences sharedPreferences;
 
   private SubscriptionDialog subscriptionDialog;  // Add this line
 
@@ -122,6 +128,16 @@ public class DefaultMessagesActivity extends AppCompatActivity
     setContentView(R.layout.activity_default_messages);
 
     messagesList = findViewById(R.id.messagesList);
+
+    sharedPreferences = getSharedPreferences("AppUsagePref", Context.MODE_PRIVATE);
+    adView = findViewById(R.id.adView);
+    boolean proUser = sharedPreferences.getBoolean("isProUser", false);
+    if (proUser) {
+      adView.setVisibility(View.GONE);
+    } else {
+      AdRequest adRequest = new AdRequest.Builder().build();
+      adView.loadAd(adRequest);
+    }
 
     // Get the intent that started this activity
     Intent intent = getIntent();
@@ -150,7 +166,7 @@ public class DefaultMessagesActivity extends AppCompatActivity
       getWindow().setStatusBarColor(ContextCompat.getColor(this, R.color.accent_color_darker));
     }
 
-    setUserSubscribed(false);
+    setUserSubscribed(proUser);
     quotaManager = new MessageQuotaManager(this, MAX_MESSAGES_PER_DAY);
     fetchAndActivateConfig();
 
@@ -411,6 +427,20 @@ public class DefaultMessagesActivity extends AppCompatActivity
 
   private void setUserSubscribed(boolean subscribed) {
     isSubscribed = subscribed;
+    if (sharedPreferences != null) {
+      sharedPreferences.edit().putBoolean("isProUser", subscribed).apply();
+    }
+    if (adView != null) {
+      if (subscribed) {
+        adView.setVisibility(View.GONE);
+      } else {
+        if (adView.getVisibility() != View.VISIBLE) {
+          adView.setVisibility(View.VISIBLE);
+        }
+        AdRequest adRequest = new AdRequest.Builder().build();
+        adView.loadAd(adRequest);
+      }
+    }
   }
 
 

--- a/feature/gpt/src/main/res/layout/activity_default_messages.xml
+++ b/feature/gpt/src/main/res/layout/activity_default_messages.xml
@@ -2,6 +2,7 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    xmlns:ads="http://schemas.android.com/apk/res-auto"
     android:id="@+id/linearLayout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -26,7 +27,7 @@
       android:layout_width="match_parent"
       android:layout_height="match_parent"
       android:layout_below="@id/toolbar"
-      android:layout_above="@+id/input"
+      android:layout_above="@+id/bottom_bar"
       app:outcomingDefaultBubbleColor="@color/outcomingDefaultBubbleColor"
       app:outcomingDefaultBubblePressedColor="@color/outcomingDefaultBubblePressedColor"
       app:outcomingDefaultBubbleSelectedColor="@color/outcomingDefaultBubbleSelectedColor"
@@ -40,23 +41,36 @@
   <View
       android:layout_width="match_parent"
       android:layout_height="1dp"
-      android:layout_above="@+id/input"
+      android:layout_above="@+id/bottom_bar"
       android:layout_marginLeft="16dp"
       android:layout_marginRight="16dp"
       android:background="@color/panel_background_color" />
 
-  <!-- Message input at the bottom -->
-  <com.stfalcon.chatkit.messages.MessageInput
-      android:id="@+id/input"
+  <!-- Ad view and message input at the bottom -->
+  <LinearLayout
+      android:id="@+id/bottom_bar"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
       android:layout_alignParentBottom="true"
-      app:inputHint="@string/message_input_hint"
-      app:inputButtonHeight="48dp"
-      app:inputButtonWidth="48dp"
-      app:inputButtonDefaultBgColor="@color/accent_color_dark"
-      app:inputButtonDefaultBgPressedColor="@color/accent_color"
-      app:inputTextColor="@color/white"
-      />
+      android:orientation="vertical">
+
+    <com.google.android.gms.ads.AdView
+        android:id="@+id/adView"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        ads:adSize="BANNER"
+        ads:adUnitId="@string/admob_banner_id" />
+
+    <com.stfalcon.chatkit.messages.MessageInput
+        android:id="@+id/input"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:inputHint="@string/message_input_hint"
+        app:inputButtonHeight="48dp"
+        app:inputButtonWidth="48dp"
+        app:inputButtonDefaultBgColor="@color/accent_color_dark"
+        app:inputButtonDefaultBgPressedColor="@color/accent_color"
+        app:inputTextColor="@color/white" />
+  </LinearLayout>
 
 </RelativeLayout>

--- a/feature/gpt/src/main/res/values/strings.xml
+++ b/feature/gpt/src/main/res/values/strings.xml
@@ -40,4 +40,5 @@ You\'ve reached your daily limit. Start your 3-day free trial for unlimited acce
   <string name="no_thanks">Maybe later</string>
   <string name="trial_conditions">• Cancel anytime\n• No charges during free trial\n• Exclusive features during trial</string>
   <string name="message_input_hint">Type your message</string>
+  <string name="admob_banner_id" translatable="false">ca-app-pub-8655759847032068/7379234820</string>
 </resources>


### PR DESCRIPTION
## Summary
- add AdMob banner to DefaultMessagesActivity and only show for non-premium users
- wire banner visibility to subscription status persistence
- include Play Services Ads dependency and banner id resource

## Testing
- `./gradlew -Dorg.gradle.jvmargs='-Xmx4g -XX:+HeapDumpOnOutOfMemoryError -XX:+UseParallelGC -Dfile.encoding=UTF-8' :feature:gpt:assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_b_68b40a109b3c832aac1206baa1f49398