### PR TITLE
Reset BillingClient after closing connection

### DIFF
--- a/feature/gpt/src/main/java/com/appcoholic/gpt/BillingHelper.java
+++ b/feature/gpt/src/main/java/com/appcoholic/gpt/BillingHelper.java
@@ -71,7 +71,10 @@ public class BillingHelper {
   }
 
   private void startConnection() {
-    if (billingClient != null && !billingClient.isReady()) {
+    if (billingClient == null) {
+      setupBillingClient();
+    }
+    if (!billingClient.isReady()) {
       billingClient.startConnection(billingClientStateListener);
     }
   }
@@ -208,6 +211,7 @@ public class BillingHelper {
   public void endConnection() {
     if (billingClient != null) {
       billingClient.endConnection();
+      billingClient = null;
     }
   }
 }


### PR DESCRIPTION
## Summary
- Ensure BillingHelper recreates BillingClient when connection was closed
- Null out BillingClient on endConnection to avoid reusing a closed client

## Testing
- `./gradlew :feature:gpt:test` *(fails: Unrecognized VM option 'MaxPermSize=512m')*

------
https://chatgpt.com/codex/tasks/task_b_68b40b26a5c8832a9c9ec8c891f76b8f