### PR TITLE
feat: add rewarded ad option for chat limit

### DIFF
--- a/feature/gpt/src/main/java/com/appcoholic/gpt/DefaultMessagesActivity.java
+++ b/feature/gpt/src/main/java/com/appcoholic/gpt/DefaultMessagesActivity.java
@@ -443,6 +443,12 @@ public class DefaultMessagesActivity extends AppCompatActivity
     }
   }
 
+  public void resetDailyChatLimit() {
+    if (quotaManager != null) {
+      quotaManager.resetQuota();
+    }
+  }
+
 
   @Override
   public boolean onCreateOptionsMenu(Menu menu) {

--- a/feature/gpt/src/main/java/com/appcoholic/gpt/MessageQuotaManager.java
+++ b/feature/gpt/src/main/java/com/appcoholic/gpt/MessageQuotaManager.java
@@ -50,6 +50,16 @@ public class MessageQuotaManager {
         this.maxMessagesPerDay = maxMessagesPerDay;
     }
 
+    /**
+     * Resets the message counter for the current day.
+     */
+    public void resetQuota() {
+        preferences.edit()
+                .putString(KEY_DATE, getCurrentDate())
+                .putInt(KEY_MESSAGE_COUNT, 0)
+                .apply();
+    }
+
     private String getCurrentDate() {
         return new SimpleDateFormat("yyyy-MM-dd", Locale.getDefault()).format(new Date());
     }

--- a/feature/gpt/src/main/java/com/appcoholic/gpt/SubscriptionDialog.java
+++ b/feature/gpt/src/main/java/com/appcoholic/gpt/SubscriptionDialog.java
@@ -15,6 +15,8 @@ import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.appcompat.widget.AppCompatButton;
+import android.content.Context;
+import android.content.ContextWrapper;
 
 import com.android.billingclient.api.ProductDetails;
 import com.android.billingclient.api.Purchase;
@@ -146,9 +148,9 @@ public class SubscriptionDialog extends Dialog implements BillingHelper.BillingU
   }
 
   private void showRewardedAd() {
-    final Activity activity = (Activity) getContext();
-    if (rewardedAd == null) {
-      Log.d("SubscriptionDialog", "The rewarded ad wasn't ready yet.");
+    final Activity activity = getActivityFromContext(getContext());
+    if (activity == null || rewardedAd == null) {
+      Log.d("SubscriptionDialog", "Unable to show rewarded ad - missing activity or ad not ready.");
       return;
     }
 
@@ -170,6 +172,16 @@ public class SubscriptionDialog extends Dialog implements BillingHelper.BillingU
         ((DefaultMessagesActivity) activity).resetDailyChatLimit();
       }
     });
+  }
+
+  private Activity getActivityFromContext(Context context) {
+    while (context instanceof ContextWrapper) {
+      if (context instanceof Activity) {
+        return (Activity) context;
+      }
+      context = ((ContextWrapper) context).getBaseContext();
+    }
+    return null;
   }
 
   @Override

--- a/feature/gpt/src/main/java/com/appcoholic/gpt/SubscriptionDialog.java
+++ b/feature/gpt/src/main/java/com/appcoholic/gpt/SubscriptionDialog.java
@@ -172,6 +172,7 @@ public class SubscriptionDialog extends Dialog implements BillingHelper.BillingU
         ((DefaultMessagesActivity) activity).resetDailyChatLimit();
       }
       dismiss();
+      Toast.makeText(activity, "Limit reset! You can now send more messages.", Toast.LENGTH_SHORT).show();
     });
   }
 

--- a/feature/gpt/src/main/java/com/appcoholic/gpt/SubscriptionDialog.java
+++ b/feature/gpt/src/main/java/com/appcoholic/gpt/SubscriptionDialog.java
@@ -171,6 +171,7 @@ public class SubscriptionDialog extends Dialog implements BillingHelper.BillingU
       if (activity instanceof DefaultMessagesActivity) {
         ((DefaultMessagesActivity) activity).resetDailyChatLimit();
       }
+      dismiss();
     });
   }
 

--- a/feature/gpt/src/main/res/layout/subscription_overlay.xml
+++ b/feature/gpt/src/main/res/layout/subscription_overlay.xml
@@ -150,6 +150,14 @@
         android:text="@string/upgrade_now"
         android:textAllCaps="false" />
 
+    <androidx.appcompat.widget.AppCompatButton
+        android:id="@+id/watch_ad_button"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:text="@string/watch_ad_and_reset_limit"
+        android:textAllCaps="false" />
+
 
     <!-- Bullet Point Texts -->
     <TextView

--- a/feature/gpt/src/main/res/values-de/strings.xml
+++ b/feature/gpt/src/main/res/values-de/strings.xml
@@ -33,6 +33,7 @@
   <string name="yearly_plan_text">Jährlich</string>
   <string name="discount_badge_text">30% Rabatt</string>
   <string name="upgrade_now">Starten Sie die 7-tägige kostenlose Testversion</string>
+  <string name="watch_ad_and_reset_limit">Werbung ansehen und Limit zurücksetzen</string>
   <string name="no_thanks">Vielleicht später</string>
   <string name="trial_conditions">• Jederzeit kündbar\n• Keine Kosten während der Testphase\n• Exklusive Funktionen während des Tests</string>
   <string name="message_input_hint">Nachricht eingeben</string>

--- a/feature/gpt/src/main/res/values/strings.xml
+++ b/feature/gpt/src/main/res/values/strings.xml
@@ -37,6 +37,7 @@ You\'ve reached your daily limit. Start your 3-day free trial for unlimited acce
   <string name="yearly_plan_text">Yearly</string>
   <string name="discount_badge_text">Save 30%</string>
   <string name="upgrade_now">Start 7 day free trial</string>
+  <string name="watch_ad_and_reset_limit">Watch ad and reset limit</string>
   <string name="no_thanks">Maybe later</string>
   <string name="trial_conditions">• Cancel anytime\n• No charges during free trial\n• Exclusive features during trial</string>
   <string name="message_input_hint">Type your message</string>


### PR DESCRIPTION
## Summary
- add `watch ad` button to subscription dialog with AdMob rewarded ad logic
- reset daily chat limit after user earns reward
- expose resetQuota helper and string resources

## Testing
- `./gradlew -Dorg.gradle.jvmargs="-Xmx4G -XX:+UseParallelGC -Dfile.encoding=UTF-8" :feature:gpt:assembleDebug` *(fails: getProperty(...) must not be null)*

------
https://chatgpt.com/codex/tasks/task_b_68b41041c290832a952a0621a90f654f