### PR TITLE
feat: add rewarded ad option for chat limit

### DIFF
--- a/feature/gpt/src/main/java/com/appcoholic/gpt/DefaultMessagesActivity.java
+++ b/feature/gpt/src/main/java/com/appcoholic/gpt/DefaultMessagesActivity.java
@@ -443,6 +443,12 @@ public class DefaultMessagesActivity extends AppCompatActivity
     }
   }
 
+  public void resetDailyChatLimit() {
+    if (quotaManager != null) {
+      quotaManager.resetQuota();
+    }
+  }
+
 
   @Override
   public boolean onCreateOptionsMenu(Menu menu) {

--- a/feature/gpt/src/main/java/com/appcoholic/gpt/MessageQuotaManager.java
+++ b/feature/gpt/src/main/java/com/appcoholic/gpt/MessageQuotaManager.java
@@ -50,6 +50,16 @@ public class MessageQuotaManager {
         this.maxMessagesPerDay = maxMessagesPerDay;
     }
 
+    /**
+     * Resets the message counter for the current day.
+     */
+    public void resetQuota() {
+        preferences.edit()
+                .putString(KEY_DATE, getCurrentDate())
+                .putInt(KEY_MESSAGE_COUNT, 0)
+                .apply();
+    }
+
     private String getCurrentDate() {
         return new SimpleDateFormat("yyyy-MM-dd", Locale.getDefault()).format(new Date());
     }

--- a/feature/gpt/src/main/java/com/appcoholic/gpt/SubscriptionDialog.java
+++ b/feature/gpt/src/main/java/com/appcoholic/gpt/SubscriptionDialog.java
@@ -52,7 +52,7 @@ public class SubscriptionDialog extends Dialog implements BillingHelper.BillingU
   private OnSubscriptionStatusChangedListener subscriptionStatusChangedListener;
 
   private RewardedAd rewardedAd;
-  private static final String REWARDED_AD_UNIT_ID = "ca-app-pub-3940256099942544/5224354917";
+  private static final String REWARDED_AD_UNIT_ID = "ca-app-pub-8655759847032068/3445692813";
 
   private AppCompatButton watchAdButton;
   private ProgressBar watchAdProgress;

--- a/feature/gpt/src/main/res/layout/subscription_overlay.xml
+++ b/feature/gpt/src/main/res/layout/subscription_overlay.xml
@@ -150,6 +150,22 @@
         android:text="@string/upgrade_now"
         android:textAllCaps="false" />
 
+    <androidx.appcompat.widget.AppCompatButton
+        android:id="@+id/watch_ad_button"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:text="@string/watch_ad_and_reset_limit"
+        android:textAllCaps="false" />
+
+    <ProgressBar
+        android:id="@+id/watch_ad_progress"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_horizontal"
+        android:layout_marginTop="16dp"
+        android:visibility="gone" />
+
 
     <!-- Bullet Point Texts -->
     <TextView

--- a/feature/gpt/src/main/res/values-de/strings.xml
+++ b/feature/gpt/src/main/res/values-de/strings.xml
@@ -33,6 +33,8 @@
   <string name="yearly_plan_text">Jährlich</string>
   <string name="discount_badge_text">30% Rabatt</string>
   <string name="upgrade_now">Starten Sie die 7-tägige kostenlose Testversion</string>
+  <string name="watch_ad_and_reset_limit">Werbung ansehen und Limit zurücksetzen</string>
+  <string name="ad_not_available">Anzeige derzeit nicht verfügbar. Bitte später erneut versuchen.</string>
   <string name="no_thanks">Vielleicht später</string>
   <string name="trial_conditions">• Jederzeit kündbar\n• Keine Kosten während der Testphase\n• Exklusive Funktionen während des Tests</string>
   <string name="message_input_hint">Nachricht eingeben</string>

--- a/feature/gpt/src/main/res/values/strings.xml
+++ b/feature/gpt/src/main/res/values/strings.xml
@@ -37,6 +37,8 @@ You\'ve reached your daily limit. Start your 3-day free trial for unlimited acce
   <string name="yearly_plan_text">Yearly</string>
   <string name="discount_badge_text">Save 30%</string>
   <string name="upgrade_now">Start 7 day free trial</string>
+  <string name="watch_ad_and_reset_limit">Watch ad and reset limit</string>
+  <string name="ad_not_available">Ad not available. Please try again later.</string>
   <string name="no_thanks">Maybe later</string>
   <string name="trial_conditions">• Cancel anytime\n• No charges during free trial\n• Exclusive features during trial</string>
   <string name="message_input_hint">Type your message</string>


### PR DESCRIPTION
## Summary
- add `watch ad` button to subscription dialog with AdMob rewarded ad logic
- reset daily chat limit after user earns reward
- expose resetQuota helper and string resources
- safely retrieve host activity when showing rewarded ad to avoid `ClassCastException`
- dismiss subscription dialog once reward is granted
- show progress indicator while loading rewarded ad and restore button with toast on failure

## Testing
- `./gradlew -Dorg.gradle.jvmargs="-Xmx4G -XX:+UseParallelGC -Dfile.encoding=UTF-8" :feature:gpt:assembleDebug` *(fails: getProperty(...) must not be null)*

------
https://chatgpt.com/codex/tasks/task_b_68b41041c290832a952a0621a90f654f