### PR TITLE
Add reward note to watch-ad strings and update translations

### DIFF
--- a/feature/gpt/src/main/res/layout/subscription_overlay.xml
+++ b/feature/gpt/src/main/res/layout/subscription_overlay.xml
@@ -171,7 +171,7 @@
 
       <View
           android:layout_width="0dp"
-          android:layout_height="1dp"
+          android:layout_height="2dp"
           android:layout_weight="1"
           android:background="@color/primary_color_dark" />
 
@@ -183,11 +183,12 @@
           android:layout_marginEnd="8dp"
           android:text="@string/or_label"
           android:textColor="@color/primary_color_dark"
-          android:textStyle="bold" />
+          android:textStyle="bold"
+          android:textSize="16sp"/>
 
       <View
           android:layout_width="0dp"
-          android:layout_height="1dp"
+          android:layout_height="2dp"
           android:layout_weight="1"
           android:background="@color/primary_color_dark" />
     </LinearLayout>
@@ -196,7 +197,7 @@
         android:id="@+id/watch_ad_button"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginTop="16dp"
+        android:layout_marginTop="8dp"
         android:text="@string/watch_ad_and_reset_limit"
         android:textAllCaps="false" />
 

--- a/feature/gpt/src/main/res/layout/subscription_overlay.xml
+++ b/feature/gpt/src/main/res/layout/subscription_overlay.xml
@@ -1,5 +1,4 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/subscription_overlay"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -43,7 +42,7 @@
         android:text="@string/premium_features_description"
         android:textAlignment="textStart"
         android:textColor="@color/gray"
-        android:textSize="16sp" />
+        android:textSize="14sp" />
 
 
     <!-- Subscription Options Container -->
@@ -51,8 +50,9 @@
         android:id="@+id/subscription_options"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginTop="16dp"
+        android:layout_marginTop="4dp"
         android:orientation="horizontal"
+        android:baselineAligned="false"
         android:padding="4dp">
 
       <!-- Monthly Plan Layout -->
@@ -64,7 +64,7 @@
           android:layout_marginEnd="8dp"
           android:orientation="vertical"
           android:background="@drawable/unselected_plan_background"
-          android:padding="16dp">
+          android:padding="8dp">
 
         <TextView
             android:id="@+id/monthly_plan_text"
@@ -100,7 +100,7 @@
           android:layout_marginStart="8dp"
           android:orientation="vertical"
           android:background="@drawable/selected_plan_background"
-          android:padding="16dp">
+          android:padding="8dp">
 
         <TextView
             android:id="@+id/yearly_plan_text"
@@ -146,9 +146,51 @@
         android:id="@+id/upgrade_button"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginTop="32dp"
+        android:layout_marginTop="16dp"
         android:text="@string/upgrade_now"
         android:textAllCaps="false" />
+
+    <!-- Bullet Point Texts -->
+    <TextView
+        android:id="@+id/trial_conditions"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/trial_conditions"
+        android:textColor="@color/gray"
+        android:textSize="14sp"
+        android:layout_marginEnd="8dp" />
+
+    <!-- divider with centered OR label -->
+    <LinearLayout
+        android:id="@+id/or_divider"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:orientation="horizontal"
+        android:gravity="center_vertical">
+
+      <View
+          android:layout_width="0dp"
+          android:layout_height="1dp"
+          android:layout_weight="1"
+          android:background="@color/primary_color_dark" />
+
+      <TextView
+          android:id="@+id/or_text_label"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_marginStart="8dp"
+          android:layout_marginEnd="8dp"
+          android:text="@string/or_label"
+          android:textColor="@color/primary_color_dark"
+          android:textStyle="bold" />
+
+      <View
+          android:layout_width="0dp"
+          android:layout_height="1dp"
+          android:layout_weight="1"
+          android:background="@color/primary_color_dark" />
+    </LinearLayout>
 
     <androidx.appcompat.widget.AppCompatButton
         android:id="@+id/watch_ad_button"
@@ -165,17 +207,6 @@
         android:layout_gravity="center_horizontal"
         android:layout_marginTop="16dp"
         android:visibility="gone" />
-
-
-    <!-- Bullet Point Texts -->
-    <TextView
-        android:id="@+id/trial_conditions"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="@string/trial_conditions"
-        android:textColor="@color/gray"
-        android:textSize="14sp"
-        android:layout_marginEnd="8dp" />
 
     <!-- divider -->
     <View

--- a/feature/gpt/src/main/res/values-ar/strings.xml
+++ b/feature/gpt/src/main/res/values-ar/strings.xml
@@ -37,4 +37,6 @@
   <string name="trial_conditions">• يمكنك الإلغاء في أي وقت\n• لا رسوم أثناء الفترة التجريبية المجانية\n• ميزات حصرية أثناء التجربة</string>
   <string name="message_input_hint">اكتب رسالتك</string>
 
+  <string name="watch_ad_and_reset_limit">شاهد الإعلان الكامل لإعادة ضبط الحد الأقصى (بدون مكافأة إذا تم تخطيه)</string>
+  <string name="ad_not_available">الإعلان غير متوفر. يرجى المحاولة مرة أخرى لاحقًا.</string>
 </resources>

--- a/feature/gpt/src/main/res/values-ar/strings.xml
+++ b/feature/gpt/src/main/res/values-ar/strings.xml
@@ -37,7 +37,7 @@
   <string name="trial_conditions">• يمكنك الإلغاء في أي وقت\n• لا رسوم أثناء الفترة التجريبية المجانية\n• ميزات حصرية أثناء التجربة</string>
   <string name="message_input_hint">اكتب رسالتك</string>
 
-  <string name="watch_ad_and_reset_limit">شاهد الإعلان الكامل لإعادة ضبط الحد الأقصى (بدون مكافأة إذا تم تخطيه)</string>
+  <string name="watch_ad_and_reset_limit">شاهد الإعلان الكامل لإعادة ضبط الحد</string>
   <string name="ad_not_available">الإعلان غير متوفر. يرجى المحاولة مرة أخرى لاحقًا.</string>
   <string name="or_label">أو</string>
 </resources>

--- a/feature/gpt/src/main/res/values-ar/strings.xml
+++ b/feature/gpt/src/main/res/values-ar/strings.xml
@@ -22,9 +22,9 @@
   <string name="qurangpt">قرآنGPT</string>
   <string name="qurangpt_pro">قرآنGPT برو</string>
 
-  <string name="upgrade_to_premium">ترقية إلى \nQuranGPT Pro</string>
+  <string name="upgrade_to_premium">ترقية إلى Pro</string>
   <string name="premium_features_description">
-    استمتع بالميزات الحصرية:\n\n
+    استمتع بالميزات الحصرية:\n
     &#8226; إجابات غير محدودة من QuranGPT.\n
     &#8226; أوقات استجابة أسرع.\n
     &#8226; ذكاء اصطناعي متقدم لتحليلات أعمق.\n
@@ -39,4 +39,5 @@
 
   <string name="watch_ad_and_reset_limit">شاهد الإعلان الكامل لإعادة ضبط الحد الأقصى (بدون مكافأة إذا تم تخطيه)</string>
   <string name="ad_not_available">الإعلان غير متوفر. يرجى المحاولة مرة أخرى لاحقًا.</string>
+  <string name="or_label">أو</string>
 </resources>

--- a/feature/gpt/src/main/res/values-az/strings.xml
+++ b/feature/gpt/src/main/res/values-az/strings.xml
@@ -37,4 +37,6 @@
   <string name="trial_conditions">• İstənilən vaxt ləğv edin\n• Pulsuz sınaq dövründə heç bir ödəniş olmayacaq\n• Sınaq müddətində eksklüziv funksiyalar</string>
   <string name="message_input_hint">Mesajınızı yazın</string>
 
+  <string name="watch_ad_and_reset_limit">Limiti yenidən qurmaq üçün tam reklamı izləyin (atlandısa mükafat yoxdur)</string>
+  <string name="ad_not_available">Reklam mövcud deyil. Xahiş edirəm daha sonra yenidən cəhd edin.</string>
 </resources>

--- a/feature/gpt/src/main/res/values-az/strings.xml
+++ b/feature/gpt/src/main/res/values-az/strings.xml
@@ -37,7 +37,7 @@
   <string name="trial_conditions">• İstənilən vaxt ləğv edin\n• Pulsuz sınaq dövründə heç bir ödəniş olmayacaq\n• Sınaq müddətində eksklüziv funksiyalar</string>
   <string name="message_input_hint">Mesajınızı yazın</string>
 
-  <string name="watch_ad_and_reset_limit">Limiti yenidən qurmaq üçün tam reklamı izləyin (atlandısa mükafat yoxdur)</string>
+  <string name="watch_ad_and_reset_limit">Limiti yenidən qurmaq üçün tam reklamı izləyin</string>
   <string name="ad_not_available">Reklam mövcud deyil. Xahiş edirəm daha sonra yenidən cəhd edin.</string>
   <string name="or_label">və ya</string>
 </resources>

--- a/feature/gpt/src/main/res/values-az/strings.xml
+++ b/feature/gpt/src/main/res/values-az/strings.xml
@@ -22,9 +22,9 @@
   <string name="qurangpt">QuranGPT</string>
   <string name="qurangpt_pro">QuranGPT Pro</string>
 
-  <string name="upgrade_to_premium">QuranGPT Pro-ya \nYüksəldin</string>
+  <string name="upgrade_to_premium">Pro-ya Yüksəldin</string>
   <string name="premium_features_description">
-    Eksklüziv premium xüsusiyyətlərdən zövq alın:\n\n
+    Eksklüziv premium xüsusiyyətlərdən zövq alın:\n
     &#8226; QuranGPT-dən limitsiz cavablar.\n
     &#8226; Daha sürətli cavab müddətləri.\n
     &#8226; Daha dərindən anlayış üçün qabaqcıl süni intellekt.\n
@@ -39,4 +39,5 @@
 
   <string name="watch_ad_and_reset_limit">Limiti yenidən qurmaq üçün tam reklamı izləyin (atlandısa mükafat yoxdur)</string>
   <string name="ad_not_available">Reklam mövcud deyil. Xahiş edirəm daha sonra yenidən cəhd edin.</string>
+  <string name="or_label">və ya</string>
 </resources>

--- a/feature/gpt/src/main/res/values-bs/strings.xml
+++ b/feature/gpt/src/main/res/values-bs/strings.xml
@@ -23,9 +23,9 @@
   <string name="qurangpt">QuranGPT</string>
   <string name="qurangpt_pro">QuranGPT Pro</string>
 
-  <string name="upgrade_to_premium">Nadogradite na \nQuranGPT Pro</string>
+  <string name="upgrade_to_premium">Nadogradite na Pro</string>
   <string name="premium_features_description">
-    Uživajte u ekskluzivnim premium funkcijama:\n\n
+    Uživajte u ekskluzivnim premium funkcijama:\n
     &#8226; Neograničeni odgovori od QuranGPT-a.\n
     &#8226; Brže vrijeme odgovora.\n
     &#8226; Napredni AI za dublje uvide.\n
@@ -40,4 +40,5 @@
 
   <string name="watch_ad_and_reset_limit">Pogledajte potpunu reklamu za resetiranje granice (bez nagrade ako preskočite)</string>
   <string name="ad_not_available">Oglas nije dostupan. Pokušajte ponovo kasnije.</string>
+  <string name="or_label">ili</string>
 </resources>

--- a/feature/gpt/src/main/res/values-bs/strings.xml
+++ b/feature/gpt/src/main/res/values-bs/strings.xml
@@ -38,4 +38,6 @@
   <string name="trial_conditions">• Možete otkazati u bilo kojem trenutku\n• Nema troškova tokom besplatnog probnog perioda\n• Ekskluzivne funkcije tokom probnog perioda</string>
   <string name="message_input_hint">Unesite poruku</string>
 
+  <string name="watch_ad_and_reset_limit">Pogledajte potpunu reklamu za resetiranje granice (bez nagrade ako preskočite)</string>
+  <string name="ad_not_available">Oglas nije dostupan. Pokušajte ponovo kasnije.</string>
 </resources>

--- a/feature/gpt/src/main/res/values-bs/strings.xml
+++ b/feature/gpt/src/main/res/values-bs/strings.xml
@@ -38,7 +38,7 @@
   <string name="trial_conditions">• Možete otkazati u bilo kojem trenutku\n• Nema troškova tokom besplatnog probnog perioda\n• Ekskluzivne funkcije tokom probnog perioda</string>
   <string name="message_input_hint">Unesite poruku</string>
 
-  <string name="watch_ad_and_reset_limit">Pogledajte potpunu reklamu za resetiranje granice (bez nagrade ako preskočite)</string>
+  <string name="watch_ad_and_reset_limit">Pogledajte potpunu reklamu za resetiranje granice</string>
   <string name="ad_not_available">Oglas nije dostupan. Pokušajte ponovo kasnije.</string>
   <string name="or_label">ili</string>
 </resources>

--- a/feature/gpt/src/main/res/values-de/strings.xml
+++ b/feature/gpt/src/main/res/values-de/strings.xml
@@ -33,7 +33,7 @@
   <string name="yearly_plan_text">Jährlich</string>
   <string name="discount_badge_text">30% Rabatt</string>
   <string name="upgrade_now">Starten Sie die 7-tägige kostenlose Testversion</string>
-  <string name="watch_ad_and_reset_limit">Werbung ansehen und Limit zurücksetzen</string>
+  <string name="watch_ad_and_reset_limit">Werbung vollständig ansehen, um das Limit zurückzusetzen (keine Belohnung bei Überspringen)</string>
   <string name="ad_not_available">Anzeige derzeit nicht verfügbar. Bitte später erneut versuchen.</string>
   <string name="no_thanks">Vielleicht später</string>
   <string name="trial_conditions">• Jederzeit kündbar\n• Keine Kosten während der Testphase\n• Exklusive Funktionen während des Tests</string>

--- a/feature/gpt/src/main/res/values-de/strings.xml
+++ b/feature/gpt/src/main/res/values-de/strings.xml
@@ -22,9 +22,9 @@
   <string name="qurangpt">QuranGPT</string>
   <string name="qurangpt_pro">QuranGPT Pro</string>
 
-  <string name="upgrade_to_premium">Upgrade zu \nQuranGPT Pro</string>
+  <string name="upgrade_to_premium">Upgrade zu Pro</string>
   <string name="premium_features_description">
-    Genießen Sie exklusive Premium-Funktionen:\n\n
+    Genießen Sie exklusive Premium-Funktionen:\n
     &#8226; Unbegrenzte Antworten von QuranGPT\n
     &#8226; Schnellere Antwortzeiten\n
     &#8226; Fortschrittliche KI für tiefere Einblicke\n
@@ -38,5 +38,5 @@
   <string name="no_thanks">Vielleicht später</string>
   <string name="trial_conditions">• Jederzeit kündbar\n• Keine Kosten während der Testphase\n• Exklusive Funktionen während des Tests</string>
   <string name="message_input_hint">Nachricht eingeben</string>
-
+  <string name="or_label">oder</string>
 </resources>

--- a/feature/gpt/src/main/res/values-de/strings.xml
+++ b/feature/gpt/src/main/res/values-de/strings.xml
@@ -33,7 +33,7 @@
   <string name="yearly_plan_text">Jährlich</string>
   <string name="discount_badge_text">30% Rabatt</string>
   <string name="upgrade_now">Starten Sie die 7-tägige kostenlose Testversion</string>
-  <string name="watch_ad_and_reset_limit">Werbung vollständig ansehen, um das Limit zurückzusetzen (keine Belohnung bei Überspringen)</string>
+  <string name="watch_ad_and_reset_limit">Werbung vollständig ansehen, um das Limit zurückzusetzen</string>
   <string name="ad_not_available">Anzeige derzeit nicht verfügbar. Bitte später erneut versuchen.</string>
   <string name="no_thanks">Vielleicht später</string>
   <string name="trial_conditions">• Jederzeit kündbar\n• Keine Kosten während der Testphase\n• Exklusive Funktionen während des Tests</string>

--- a/feature/gpt/src/main/res/values-es/strings.xml
+++ b/feature/gpt/src/main/res/values-es/strings.xml
@@ -23,9 +23,9 @@
   <string name="qurangpt">QuranGPT</string>
   <string name="qurangpt_pro">QuranGPT Pro</string>
 
-  <string name="upgrade_to_premium">Actualiza a \nQuranGPT Pro</string>
+  <string name="upgrade_to_premium">Actualiza a Pro</string>
   <string name="premium_features_description">
-    Disfruta de funciones premium exclusivas:\n\n
+    Disfruta de funciones premium exclusivas:\n
     &#8226; Respuestas ilimitadas de QuranGPT.\n
     &#8226; Tiempos de respuesta más rápidos.\n
     &#8226; IA avanzada para análisis más profundos.\n
@@ -40,4 +40,5 @@
 
   <string name="watch_ad_and_reset_limit">Mire el anuncio completo para restablecer el límite (sin recompensa si se omite)</string>
   <string name="ad_not_available">Anuncio no disponible. Vuelva a intentarlo más tarde.</string>
+  <string name="or_label">o</string>
 </resources>

--- a/feature/gpt/src/main/res/values-es/strings.xml
+++ b/feature/gpt/src/main/res/values-es/strings.xml
@@ -38,7 +38,7 @@
   <string name="trial_conditions">• Cancela en cualquier momento\n• Sin cargos durante el periodo de prueba gratuito\n• Funciones exclusivas durante la prueba</string>
   <string name="message_input_hint">Escribe tu mensaje</string>
 
-  <string name="watch_ad_and_reset_limit">Mire el anuncio completo para restablecer el límite (sin recompensa si se omite)</string>
+  <string name="watch_ad_and_reset_limit">Mire el anuncio completo para restablecer el límite</string>
   <string name="ad_not_available">Anuncio no disponible. Vuelva a intentarlo más tarde.</string>
   <string name="or_label">o</string>
 </resources>

--- a/feature/gpt/src/main/res/values-es/strings.xml
+++ b/feature/gpt/src/main/res/values-es/strings.xml
@@ -38,4 +38,6 @@
   <string name="trial_conditions">• Cancela en cualquier momento\n• Sin cargos durante el periodo de prueba gratuito\n• Funciones exclusivas durante la prueba</string>
   <string name="message_input_hint">Escribe tu mensaje</string>
 
+  <string name="watch_ad_and_reset_limit">Mire el anuncio completo para restablecer el límite (sin recompensa si se omite)</string>
+  <string name="ad_not_available">Anuncio no disponible. Vuelva a intentarlo más tarde.</string>
 </resources>

--- a/feature/gpt/src/main/res/values-fa/strings.xml
+++ b/feature/gpt/src/main/res/values-fa/strings.xml
@@ -38,4 +38,6 @@
   <string name="trial_conditions">• امکان لغو در هر زمان\n• بدون هزینه در طول دوره آزمایشی رایگان\n• ویژگی‌های انحصاری در طول دوره آزمایشی</string>
   <string name="message_input_hint">پیام خود را بنویسید</string>
 
+  <string name="watch_ad_and_reset_limit">تبلیغات کامل را برای تنظیم مجدد حد مشاهده کنید (در صورت پرش، پاداشی نیست)</string>
+  <string name="ad_not_available">تبلیغ در دسترس نیست. لطفا بعداً دوباره امتحان کنید.</string>
 </resources>

--- a/feature/gpt/src/main/res/values-fa/strings.xml
+++ b/feature/gpt/src/main/res/values-fa/strings.xml
@@ -38,7 +38,7 @@
   <string name="trial_conditions">• امکان لغو در هر زمان\n• بدون هزینه در طول دوره آزمایشی رایگان\n• ویژگی‌های انحصاری در طول دوره آزمایشی</string>
   <string name="message_input_hint">پیام خود را بنویسید</string>
 
-  <string name="watch_ad_and_reset_limit">تبلیغات کامل را برای تنظیم مجدد حد مشاهده کنید (در صورت پرش، پاداشی نیست)</string>
+  <string name="watch_ad_and_reset_limit">تبلیغات کامل را برای تنظیم مجدد حد مشاهده کنید</string>
   <string name="ad_not_available">تبلیغ در دسترس نیست. لطفا بعداً دوباره امتحان کنید.</string>
   <string name="or_label">یا</string>
 </resources>

--- a/feature/gpt/src/main/res/values-fa/strings.xml
+++ b/feature/gpt/src/main/res/values-fa/strings.xml
@@ -23,9 +23,9 @@
   <string name="qurangpt">قرآنGPT</string>
   <string name="qurangpt_pro">قرآنGPT Pro</string>
 
-  <string name="upgrade_to_premium">ارتقا به \nQuranGPT Pro</string>
+  <string name="upgrade_to_premium">ارتقا به Pro</string>
   <string name="premium_features_description">
-    از ویژگی‌های ویژه پرمیوم لذت ببرید:\n\n
+    از ویژگی‌های ویژه پرمیوم لذت ببرید:\n
     &#8226; پاسخ‌های نامحدود از QuranGPT.\n
     &#8226; زمان پاسخ‌دهی سریع‌تر.\n
     &#8226; هوش مصنوعی پیشرفته برای بینش‌های عمیق‌تر.\n
@@ -40,4 +40,5 @@
 
   <string name="watch_ad_and_reset_limit">تبلیغات کامل را برای تنظیم مجدد حد مشاهده کنید (در صورت پرش، پاداشی نیست)</string>
   <string name="ad_not_available">تبلیغ در دسترس نیست. لطفا بعداً دوباره امتحان کنید.</string>
+  <string name="or_label">یا</string>
 </resources>

--- a/feature/gpt/src/main/res/values-fr/strings.xml
+++ b/feature/gpt/src/main/res/values-fr/strings.xml
@@ -38,4 +38,6 @@
   <string name="trial_conditions">• Annulez à tout moment\n• Aucun frais pendant la période d\'essai gratuite\n• Fonctionnalités exclusives pendant l\'essai</string>
   <string name="message_input_hint">Écrivez votre message</string>
 
+  <string name="watch_ad_and_reset_limit">Regardez la publicité complète pour réinitialiser la limite (pas de récompense si elle est ignorée)</string>
+  <string name="ad_not_available">Publicité non disponible. Veuillez réessayer plus tard.</string>
 </resources>

--- a/feature/gpt/src/main/res/values-fr/strings.xml
+++ b/feature/gpt/src/main/res/values-fr/strings.xml
@@ -23,9 +23,9 @@
   <string name="qurangpt">QuranGPT</string>
   <string name="qurangpt_pro">QuranGPT Pro</string>
 
-  <string name="upgrade_to_premium">Passer à \nQuranGPT Pro</string>
+  <string name="upgrade_to_premium">Passer à Pro</string>
   <string name="premium_features_description">
-    Profitez des fonctionnalités exclusives premium :\n\n
+    Profitez des fonctionnalités exclusives premium :\n
     &#8226; Réponses illimitées de QuranGPT.\n
     &#8226; Temps de réponse plus rapides.\n
     &#8226; IA avancée pour des analyses plus approfondies.\n
@@ -40,4 +40,5 @@
 
   <string name="watch_ad_and_reset_limit">Regardez la publicité complète pour réinitialiser la limite (pas de récompense si elle est ignorée)</string>
   <string name="ad_not_available">Publicité non disponible. Veuillez réessayer plus tard.</string>
+  <string name="or_label">ou</string>
 </resources>

--- a/feature/gpt/src/main/res/values-fr/strings.xml
+++ b/feature/gpt/src/main/res/values-fr/strings.xml
@@ -38,7 +38,7 @@
   <string name="trial_conditions">• Annulez à tout moment\n• Aucun frais pendant la période d\'essai gratuite\n• Fonctionnalités exclusives pendant l\'essai</string>
   <string name="message_input_hint">Écrivez votre message</string>
 
-  <string name="watch_ad_and_reset_limit">Regardez la publicité complète pour réinitialiser la limite (pas de récompense si elle est ignorée)</string>
+  <string name="watch_ad_and_reset_limit">Regardez la publicité complète pour réinitialiser la limite</string>
   <string name="ad_not_available">Publicité non disponible. Veuillez réessayer plus tard.</string>
   <string name="or_label">ou</string>
 </resources>

--- a/feature/gpt/src/main/res/values-hr/strings.xml
+++ b/feature/gpt/src/main/res/values-hr/strings.xml
@@ -38,4 +38,6 @@
   <string name="trial_conditions">• Otkazivanje u bilo kojem trenutku\n• Nema troškova tijekom besplatnog probnog razdoblja\n• Ekskluzivne značajke tijekom probnog razdoblja</string>
   <string name="message_input_hint">Upišite poruku</string>
 
+  <string name="watch_ad_and_reset_limit">Pogledajte cijeli oglas kako biste resetirali ograničenje (bez nagrade ako je preskočen)</string>
+  <string name="ad_not_available">Oglas nije dostupan. Molimo pokušajte ponovo kasnije.</string>
 </resources>

--- a/feature/gpt/src/main/res/values-hr/strings.xml
+++ b/feature/gpt/src/main/res/values-hr/strings.xml
@@ -23,9 +23,9 @@
   <string name="qurangpt">QuranGPT</string>
   <string name="qurangpt_pro">QuranGPT Pro</string>
 
-  <string name="upgrade_to_premium">Nadogradi na \nQuranGPT Pro</string>
+  <string name="upgrade_to_premium">Nadogradi na Pro</string>
   <string name="premium_features_description">
-    Uživajte u ekskluzivnim premium značajkama:\n\n
+    Uživajte u ekskluzivnim premium značajkama:\n
     &#8226; Neograničeni odgovori od QuranGPT-a.\n
     &#8226; Brži vremenski odgovori.\n
     &#8226; Napredna AI za dublje uvide.\n
@@ -40,4 +40,5 @@
 
   <string name="watch_ad_and_reset_limit">Pogledajte cijeli oglas kako biste resetirali ograničenje (bez nagrade ako je preskočen)</string>
   <string name="ad_not_available">Oglas nije dostupan. Molimo pokušajte ponovo kasnije.</string>
+  <string name="or_label">ili</string>
 </resources>

--- a/feature/gpt/src/main/res/values-hr/strings.xml
+++ b/feature/gpt/src/main/res/values-hr/strings.xml
@@ -38,7 +38,7 @@
   <string name="trial_conditions">• Otkazivanje u bilo kojem trenutku\n• Nema troškova tijekom besplatnog probnog razdoblja\n• Ekskluzivne značajke tijekom probnog razdoblja</string>
   <string name="message_input_hint">Upišite poruku</string>
 
-  <string name="watch_ad_and_reset_limit">Pogledajte cijeli oglas kako biste resetirali ograničenje (bez nagrade ako je preskočen)</string>
+  <string name="watch_ad_and_reset_limit">Pogledajte cijeli oglas kako biste resetirali ograničenje</string>
   <string name="ad_not_available">Oglas nije dostupan. Molimo pokušajte ponovo kasnije.</string>
   <string name="or_label">ili</string>
 </resources>

--- a/feature/gpt/src/main/res/values-hu/strings.xml
+++ b/feature/gpt/src/main/res/values-hu/strings.xml
@@ -23,9 +23,9 @@
   <string name="qurangpt">QuranGPT</string>
   <string name="qurangpt_pro">QuranGPT Pro</string>
 
-  <string name="upgrade_to_premium">Frissítés \nQuranGPT Pro-ra</string>
+  <string name="upgrade_to_premium">Frissítés Pro-ra</string>
   <string name="premium_features_description">
-    Élvezze a prémium funkciókat:\n\n
+    Élvezze a prémium funkciókat:\n
     &#8226; Korlátlan válaszok a QuranGPT-től.\n
     &#8226; Gyorsabb válaszidők.\n
     &#8226; Fejlett mesterséges intelligencia mélyebb betekintéshez.\n
@@ -40,4 +40,5 @@
 
   <string name="watch_ad_and_reset_limit">Nézze meg a teljes hirdetést, hogy visszaállítsa a korlátot (nincs jutalom, ha kihagyja)</string>
   <string name="ad_not_available">A hirdetés nem érhető el. Kérjük, próbálkozzon újra később.</string>
+  <string name="or_label">vagy</string>
 </resources>

--- a/feature/gpt/src/main/res/values-hu/strings.xml
+++ b/feature/gpt/src/main/res/values-hu/strings.xml
@@ -38,7 +38,7 @@
   <string name="trial_conditions">• Bármikor lemondható\n• Ingyenes próbaidőszak alatt nincs díj\n• Exkluzív funkciók a próbaidőszak alatt</string>
   <string name="message_input_hint">Írja be üzenetét</string>
 
-  <string name="watch_ad_and_reset_limit">Nézze meg a teljes hirdetést, hogy visszaállítsa a korlátot (nincs jutalom, ha kihagyja)</string>
+  <string name="watch_ad_and_reset_limit">Nézze meg a teljes hirdetést a korlát visszaállításához</string>
   <string name="ad_not_available">A hirdetés nem érhető el. Kérjük, próbálkozzon újra később.</string>
   <string name="or_label">vagy</string>
 </resources>

--- a/feature/gpt/src/main/res/values-hu/strings.xml
+++ b/feature/gpt/src/main/res/values-hu/strings.xml
@@ -38,4 +38,6 @@
   <string name="trial_conditions">• Bármikor lemondható\n• Ingyenes próbaidőszak alatt nincs díj\n• Exkluzív funkciók a próbaidőszak alatt</string>
   <string name="message_input_hint">Írja be üzenetét</string>
 
+  <string name="watch_ad_and_reset_limit">Nézze meg a teljes hirdetést, hogy visszaállítsa a korlátot (nincs jutalom, ha kihagyja)</string>
+  <string name="ad_not_available">A hirdetés nem érhető el. Kérjük, próbálkozzon újra később.</string>
 </resources>

--- a/feature/gpt/src/main/res/values-in/strings.xml
+++ b/feature/gpt/src/main/res/values-in/strings.xml
@@ -37,7 +37,7 @@
   <string name="trial_conditions">• Batalkan kapan saja\n• Tidak ada biaya selama masa uji coba gratis\n• Fitur eksklusif selama masa uji coba</string>
   <string name="message_input_hint">Ketik pesan Anda</string>
 
-  <string name="watch_ad_and_reset_limit">Tonton iklan lengkap untuk mengatur ulang batas (tidak ada hadiah jika dilewati)</string>
+  <string name="watch_ad_and_reset_limit">Tonton iklan lengkap untuk mengatur ulang batas</string>
   <string name="ad_not_available">Iklan tidak tersedia. Silakan coba lagi nanti.</string>
   <string name="or_label">atau</string>
 </resources>

--- a/feature/gpt/src/main/res/values-in/strings.xml
+++ b/feature/gpt/src/main/res/values-in/strings.xml
@@ -37,4 +37,6 @@
   <string name="trial_conditions">• Batalkan kapan saja\n• Tidak ada biaya selama masa uji coba gratis\n• Fitur eksklusif selama masa uji coba</string>
   <string name="message_input_hint">Ketik pesan Anda</string>
 
+  <string name="watch_ad_and_reset_limit">Tonton iklan lengkap untuk mengatur ulang batas (tidak ada hadiah jika dilewati)</string>
+  <string name="ad_not_available">Iklan tidak tersedia. Silakan coba lagi nanti.</string>
 </resources>

--- a/feature/gpt/src/main/res/values-in/strings.xml
+++ b/feature/gpt/src/main/res/values-in/strings.xml
@@ -22,9 +22,9 @@
   <string name="qurangpt">QuranGPT</string>
   <string name="qurangpt_pro">QuranGPT Pro</string>
 
-  <string name="upgrade_to_premium">Upgrade ke \nQuranGPT Pro</string>
+  <string name="upgrade_to_premium">Upgrade ke Pro</string>
   <string name="premium_features_description">
-    Nikmati fitur premium eksklusif:\n\n
+    Nikmati fitur premium eksklusif:\n
     &#8226; Jawaban tanpa batas dari QuranGPT.\n
     &#8226; Waktu respons lebih cepat.\n
     &#8226; AI canggih untuk wawasan yang lebih dalam.\n
@@ -39,4 +39,5 @@
 
   <string name="watch_ad_and_reset_limit">Tonton iklan lengkap untuk mengatur ulang batas (tidak ada hadiah jika dilewati)</string>
   <string name="ad_not_available">Iklan tidak tersedia. Silakan coba lagi nanti.</string>
+  <string name="or_label">atau</string>
 </resources>

--- a/feature/gpt/src/main/res/values-it/strings.xml
+++ b/feature/gpt/src/main/res/values-it/strings.xml
@@ -38,4 +38,6 @@
   <string name="trial_conditions">• Annulla in qualsiasi momento\n• Nessun addebito durante il periodo di prova gratuito\n• Funzionalità esclusive durante la prova</string>
   <string name="message_input_hint">Scrivi il tuo messaggio</string>
 
+  <string name="watch_ad_and_reset_limit">Guarda la pubblicità completa per ripristinare il limite (nessuna ricompensa se saltata)</string>
+  <string name="ad_not_available">Pubblicità non disponibile. Per favore riprova più tardi.</string>
 </resources>

--- a/feature/gpt/src/main/res/values-it/strings.xml
+++ b/feature/gpt/src/main/res/values-it/strings.xml
@@ -23,9 +23,9 @@
   <string name="qurangpt">QuranGPT</string>
   <string name="qurangpt_pro">QuranGPT Pro</string>
 
-  <string name="upgrade_to_premium">Aggiorna a \nQuranGPT Pro</string>
+  <string name="upgrade_to_premium">Aggiorna a Pro</string>
   <string name="premium_features_description">
-    Goditi le funzionalità premium esclusive:\n\n
+    Goditi le funzionalità premium esclusive:\n
     &#8226; Risposte illimitate da QuranGPT.\n
     &#8226; Tempi di risposta più veloci.\n
     &#8226; AI avanzata per approfondimenti più profondi.\n
@@ -40,4 +40,5 @@
 
   <string name="watch_ad_and_reset_limit">Guarda la pubblicità completa per ripristinare il limite (nessuna ricompensa se saltata)</string>
   <string name="ad_not_available">Pubblicità non disponibile. Per favore riprova più tardi.</string>
+  <string name="or_label">o</string>
 </resources>

--- a/feature/gpt/src/main/res/values-it/strings.xml
+++ b/feature/gpt/src/main/res/values-it/strings.xml
@@ -38,7 +38,7 @@
   <string name="trial_conditions">• Annulla in qualsiasi momento\n• Nessun addebito durante il periodo di prova gratuito\n• Funzionalità esclusive durante la prova</string>
   <string name="message_input_hint">Scrivi il tuo messaggio</string>
 
-  <string name="watch_ad_and_reset_limit">Guarda la pubblicità completa per ripristinare il limite (nessuna ricompensa se saltata)</string>
+  <string name="watch_ad_and_reset_limit">Guarda la pubblicità completa per ripristinare il limite</string>
   <string name="ad_not_available">Pubblicità non disponibile. Per favore riprova più tardi.</string>
   <string name="or_label">o</string>
 </resources>

--- a/feature/gpt/src/main/res/values-kk/strings.xml
+++ b/feature/gpt/src/main/res/values-kk/strings.xml
@@ -37,4 +37,6 @@
   <string name="trial_conditions">• Кез келген уақытта бас тартуға болады\n• Тегін сынақ кезеңінде ешқандай төлем болмайды\n• Сынақ кезеңінде эксклюзивті мүмкіндіктер</string>
   <string name="message_input_hint">Хабарламаңызды жазыңыз</string>
 
+  <string name="watch_ad_and_reset_limit">Шекті қалпына келтіру үшін толық жарнаманы қараңыз (өткізіп жіберілсе, сыйақы жоқ)</string>
+  <string name="ad_not_available">Жарнама қолжетімді емес. Кейінірек қайтадан байқап көріңіз.</string>
 </resources>

--- a/feature/gpt/src/main/res/values-kk/strings.xml
+++ b/feature/gpt/src/main/res/values-kk/strings.xml
@@ -22,9 +22,9 @@
 
   <string name="qurangpt">ҚұранGPT</string>
   <string name="qurangpt_pro">ҚұранGPT Pro</string>
-  <string name="upgrade_to_premium">QuranGPT Pro-ға \nЖаңартыңыз</string>
+  <string name="upgrade_to_premium">Pro-ға Жаңартыңыз</string>
   <string name="premium_features_description">
-    Эксклюзивті премиум мүмкіндіктерінен рахат алыңыз:\n\n
+    Эксклюзивті премиум мүмкіндіктерінен рахат алыңыз:\n
     &#8226; QuranGPT-тен шексіз жауаптар.\n
     &#8226; Жылдам жауап беру уақыты.\n
     &#8226; Терең түсініктер үшін жетілдірілген AI.\n
@@ -39,4 +39,5 @@
 
   <string name="watch_ad_and_reset_limit">Шекті қалпына келтіру үшін толық жарнаманы қараңыз (өткізіп жіберілсе, сыйақы жоқ)</string>
   <string name="ad_not_available">Жарнама қолжетімді емес. Кейінірек қайтадан байқап көріңіз.</string>
+  <string name="or_label">немесе</string>
 </resources>

--- a/feature/gpt/src/main/res/values-kk/strings.xml
+++ b/feature/gpt/src/main/res/values-kk/strings.xml
@@ -37,7 +37,7 @@
   <string name="trial_conditions">• Кез келген уақытта бас тартуға болады\n• Тегін сынақ кезеңінде ешқандай төлем болмайды\n• Сынақ кезеңінде эксклюзивті мүмкіндіктер</string>
   <string name="message_input_hint">Хабарламаңызды жазыңыз</string>
 
-  <string name="watch_ad_and_reset_limit">Шекті қалпына келтіру үшін толық жарнаманы қараңыз (өткізіп жіберілсе, сыйақы жоқ)</string>
+  <string name="watch_ad_and_reset_limit">Шекті қалпына келтіру үшін толық жарнаманы қараңыз</string>
   <string name="ad_not_available">Жарнама қолжетімді емес. Кейінірек қайтадан байқап көріңіз.</string>
   <string name="or_label">немесе</string>
 </resources>

--- a/feature/gpt/src/main/res/values-ku/strings.xml
+++ b/feature/gpt/src/main/res/values-ku/strings.xml
@@ -38,4 +38,6 @@
   <string name="trial_conditions">• هەر کاتیش لەماوەدا ڕەت کردنەوە دەکرێت\n• هیچ تەرخانێکی نییە لە ماوەی تاقیکردنەوەی بێتاکەوە\n• تایبەتمەندیە تایبەتییەکان لە ماوەی تاقیکردنەوەدا</string>
   <string name="message_input_hint">پەیامەکەت بنووسە</string>
 
+  <string name="watch_ad_and_reset_limit">Reklama tevahî bibîne bo vegerandina sînorê (xelet nabe heke derbas bibe)</string>
+  <string name="ad_not_available">Reklam nabe. Ji kerema xwe paşê paşê biceribînin.</string>
 </resources>

--- a/feature/gpt/src/main/res/values-ku/strings.xml
+++ b/feature/gpt/src/main/res/values-ku/strings.xml
@@ -23,9 +23,9 @@
   <string name="qurangpt">QuranGPT</string>
   <string name="qurangpt_pro">QuranGPT Pro</string>
 
-  <string name="upgrade_to_premium">نوێکردنەوە بۆ\nQuranGPT Pro</string>
+  <string name="upgrade_to_premium">نوێکردنەوە بۆ Pro</string>
   <string name="premium_features_description">
-    سوود بەرهەم بگەرە لە تایبەتمەندیە تایبەتیەکان:\n\n
+    سوود بەرهەم بگەرە لە تایبەتمەندیە تایبەتیەکان:\n
     &#8226; وەڵامەکانی قورئان GPT بێ سنوور.\n
     &#8226; کاتی وەڵامی خێراتر.\n
     &#8226; AI پێشکەوتوو بۆ بینینی هەستیارتر.\n
@@ -40,4 +40,5 @@
 
   <string name="watch_ad_and_reset_limit">Reklama tevahî bibîne bo vegerandina sînorê (xelet nabe heke derbas bibe)</string>
   <string name="ad_not_available">Reklam nabe. Ji kerema xwe paşê paşê biceribînin.</string>
+  <string name="or_label">یان</string>
 </resources>

--- a/feature/gpt/src/main/res/values-ku/strings.xml
+++ b/feature/gpt/src/main/res/values-ku/strings.xml
@@ -38,7 +38,7 @@
   <string name="trial_conditions">• هەر کاتیش لەماوەدا ڕەت کردنەوە دەکرێت\n• هیچ تەرخانێکی نییە لە ماوەی تاقیکردنەوەی بێتاکەوە\n• تایبەتمەندیە تایبەتییەکان لە ماوەی تاقیکردنەوەدا</string>
   <string name="message_input_hint">پەیامەکەت بنووسە</string>
 
-  <string name="watch_ad_and_reset_limit">Reklama tevahî bibîne bo vegerandina sînorê (xelet nabe heke derbas bibe)</string>
+  <string name="watch_ad_and_reset_limit">Reklama tevahî bibîne bo vegerandina sînorê</string>
   <string name="ad_not_available">Reklam nabe. Ji kerema xwe paşê paşê biceribînin.</string>
   <string name="or_label">یان</string>
 </resources>

--- a/feature/gpt/src/main/res/values-ms/strings.xml
+++ b/feature/gpt/src/main/res/values-ms/strings.xml
@@ -21,9 +21,9 @@
 
   <string name="qurangpt">QuranGPT</string>
   <string name="qurangpt_pro">QuranGPT Pro</string>
-  <string name="upgrade_to_premium">Tingkatkan ke \nQuranGPT Pro</string>
+  <string name="upgrade_to_premium">Tingkatkan ke Pro</string>
   <string name="premium_features_description">
-    Nikmati ciri premium eksklusif:\n\n
+    Nikmati ciri premium eksklusif:\n
     &#8226; Jawapan QuranGPT tanpa had.\n
     &#8226; Masa respons lebih pantas.\n
     &#8226; AI maju untuk pandangan yang lebih mendalam.\n
@@ -38,4 +38,5 @@
 
   <string name="watch_ad_and_reset_limit">Tonton iklan penuh untuk menetapkan semula had (tiada ganjaran jika dilangkau)</string>
   <string name="ad_not_available">Iklan tidak tersedia. Sila cuba lagi kemudian.</string>
+  <string name="or_label">atau</string>
 </resources>

--- a/feature/gpt/src/main/res/values-ms/strings.xml
+++ b/feature/gpt/src/main/res/values-ms/strings.xml
@@ -36,4 +36,6 @@
   <string name="trial_conditions">• Boleh dibatalkan bila-bila masa\n• Tiada caj semasa percubaan percuma\n• Ciri eksklusif semasa percubaan</string>
   <string name="message_input_hint">Taip mesej anda</string>
 
+  <string name="watch_ad_and_reset_limit">Tonton iklan penuh untuk menetapkan semula had (tiada ganjaran jika dilangkau)</string>
+  <string name="ad_not_available">Iklan tidak tersedia. Sila cuba lagi kemudian.</string>
 </resources>

--- a/feature/gpt/src/main/res/values-ms/strings.xml
+++ b/feature/gpt/src/main/res/values-ms/strings.xml
@@ -36,7 +36,7 @@
   <string name="trial_conditions">• Boleh dibatalkan bila-bila masa\n• Tiada caj semasa percubaan percuma\n• Ciri eksklusif semasa percubaan</string>
   <string name="message_input_hint">Taip mesej anda</string>
 
-  <string name="watch_ad_and_reset_limit">Tonton iklan penuh untuk menetapkan semula had (tiada ganjaran jika dilangkau)</string>
+  <string name="watch_ad_and_reset_limit">Tonton iklan penuh untuk menetapkan semula had</string>
   <string name="ad_not_available">Iklan tidak tersedia. Sila cuba lagi kemudian.</string>
   <string name="or_label">atau</string>
 </resources>

--- a/feature/gpt/src/main/res/values-nl/strings.xml
+++ b/feature/gpt/src/main/res/values-nl/strings.xml
@@ -37,4 +37,6 @@
   <string name="trial_conditions">• Annuleer op elk moment\n• Geen kosten tijdens de gratis proefperiode\n• Exclusieve functies tijdens de proefperiode</string>
   <string name="message_input_hint">Typ je bericht</string>
 
+  <string name="watch_ad_and_reset_limit">Bekijk de volledige advertentie om de limiet te resetten (geen beloning als deze wordt overgeslagen)</string>
+  <string name="ad_not_available">Advertentie niet beschikbaar. Probeer het later opnieuw.</string>
 </resources>

--- a/feature/gpt/src/main/res/values-nl/strings.xml
+++ b/feature/gpt/src/main/res/values-nl/strings.xml
@@ -37,7 +37,7 @@
   <string name="trial_conditions">• Annuleer op elk moment\n• Geen kosten tijdens de gratis proefperiode\n• Exclusieve functies tijdens de proefperiode</string>
   <string name="message_input_hint">Typ je bericht</string>
 
-  <string name="watch_ad_and_reset_limit">Bekijk de volledige advertentie om de limiet te resetten (geen beloning als deze wordt overgeslagen)</string>
+  <string name="watch_ad_and_reset_limit">Bekijk de volledige advertentie om de limiet te resetten</string>
   <string name="ad_not_available">Advertentie niet beschikbaar. Probeer het later opnieuw.</string>
   <string name="or_label">of</string>
 </resources>

--- a/feature/gpt/src/main/res/values-nl/strings.xml
+++ b/feature/gpt/src/main/res/values-nl/strings.xml
@@ -22,9 +22,9 @@
 
   <string name="qurangpt">QuranGPT</string>
   <string name="qurangpt_pro">QuranGPT Pro</string>
-  <string name="upgrade_to_premium">Upgrade naar \nQuranGPT Pro</string>
+  <string name="upgrade_to_premium">Upgrade naar Pro</string>
   <string name="premium_features_description">
-    Geniet van exclusieve premium functies:\n\n
+    Geniet van exclusieve premium functies:\n
     &#8226; Onbeperkte antwoorden van QuranGPT.\n
     &#8226; Snellere reactietijden.\n
     &#8226; Geavanceerde AI voor diepgaandere inzichten.\n
@@ -39,4 +39,5 @@
 
   <string name="watch_ad_and_reset_limit">Bekijk de volledige advertentie om de limiet te resetten (geen beloning als deze wordt overgeslagen)</string>
   <string name="ad_not_available">Advertentie niet beschikbaar. Probeer het later opnieuw.</string>
+  <string name="or_label">of</string>
 </resources>

--- a/feature/gpt/src/main/res/values-pl/strings.xml
+++ b/feature/gpt/src/main/res/values-pl/strings.xml
@@ -36,4 +36,6 @@
   <string name="trial_conditions">• Anuluj w dowolnym momencie\n• Brak opłat podczas bezpłatnego okresu próbnego\n• Ekskluzywne funkcje podczas okresu próbnego</string>
   <string name="message_input_hint">Wpisz wiadomość</string>
 
+  <string name="watch_ad_and_reset_limit">Obejrzyj pełną reklamę, aby zresetować limit (bez nagrody, jeśli zostanie pominięta)</string>
+  <string name="ad_not_available">Reklama niedostępna. Spróbuj ponownie później.</string>
 </resources>

--- a/feature/gpt/src/main/res/values-pl/strings.xml
+++ b/feature/gpt/src/main/res/values-pl/strings.xml
@@ -36,7 +36,7 @@
   <string name="trial_conditions">• Anuluj w dowolnym momencie\n• Brak opłat podczas bezpłatnego okresu próbnego\n• Ekskluzywne funkcje podczas okresu próbnego</string>
   <string name="message_input_hint">Wpisz wiadomość</string>
 
-  <string name="watch_ad_and_reset_limit">Obejrzyj pełną reklamę, aby zresetować limit (bez nagrody, jeśli zostanie pominięta)</string>
+  <string name="watch_ad_and_reset_limit">Obejrzyj pełną reklamę, aby zresetować limit</string>
   <string name="ad_not_available">Reklama niedostępna. Spróbuj ponownie później.</string>
   <string name="or_label">lub</string>
 </resources>

--- a/feature/gpt/src/main/res/values-pl/strings.xml
+++ b/feature/gpt/src/main/res/values-pl/strings.xml
@@ -21,9 +21,9 @@
 
   <string name="qurangpt">QuranGPT</string>
   <string name="qurangpt_pro">QuranGPT Pro</string>
-  <string name="upgrade_to_premium">Ulepsz do \nQuranGPT Pro</string>
+  <string name="upgrade_to_premium">Ulepsz do Pro</string>
   <string name="premium_features_description">
-    Ciesz się ekskluzywnymi funkcjami premium:\n\n
+    Ciesz się ekskluzywnymi funkcjami premium:\n
     &#8226; Nieograniczone odpowiedzi od QuranGPT.\n
     &#8226; Szybsze czasy odpowiedzi.\n
     &#8226; Zaawansowana AI dla głębszych analiz.\n
@@ -38,4 +38,5 @@
 
   <string name="watch_ad_and_reset_limit">Obejrzyj pełną reklamę, aby zresetować limit (bez nagrody, jeśli zostanie pominięta)</string>
   <string name="ad_not_available">Reklama niedostępna. Spróbuj ponownie później.</string>
+  <string name="or_label">lub</string>
 </resources>

--- a/feature/gpt/src/main/res/values-pt/strings.xml
+++ b/feature/gpt/src/main/res/values-pt/strings.xml
@@ -37,7 +37,7 @@
   <string name="trial_conditions">• Cancele a qualquer momento\n• Sem cobranças durante o período de teste gratuito\n• Recursos exclusivos durante o teste</string>
   <string name="message_input_hint">Digite sua mensagem</string>
 
-  <string name="watch_ad_and_reset_limit">Assista ao anúncio completo para redefinir o limite (sem recompensa se ignorado)</string>
+  <string name="watch_ad_and_reset_limit">Assista ao anúncio completo para redefinir o limite</string>
   <string name="ad_not_available">Anúncio não disponível. Por favor, tente novamente mais tarde.</string>
   <string name="or_label">ou</string>
 </resources>

--- a/feature/gpt/src/main/res/values-pt/strings.xml
+++ b/feature/gpt/src/main/res/values-pt/strings.xml
@@ -37,4 +37,6 @@
   <string name="trial_conditions">• Cancele a qualquer momento\n• Sem cobranças durante o período de teste gratuito\n• Recursos exclusivos durante o teste</string>
   <string name="message_input_hint">Digite sua mensagem</string>
 
+  <string name="watch_ad_and_reset_limit">Assista ao anúncio completo para redefinir o limite (sem recompensa se ignorado)</string>
+  <string name="ad_not_available">Anúncio não disponível. Por favor, tente novamente mais tarde.</string>
 </resources>

--- a/feature/gpt/src/main/res/values-pt/strings.xml
+++ b/feature/gpt/src/main/res/values-pt/strings.xml
@@ -22,9 +22,9 @@
 
   <string name="qurangpt">QuranGPT</string>
   <string name="qurangpt_pro">QuranGPT Pro</string>
-  <string name="upgrade_to_premium">Atualize para \nQuranGPT Pro</string>
+  <string name="upgrade_to_premium">Atualize para Pro</string>
   <string name="premium_features_description">
-    Aproveite recursos premium exclusivos:\n\n
+    Aproveite recursos premium exclusivos:\n
     &#8226; Respostas ilimitadas do QuranGPT.\n
     &#8226; Tempos de resposta mais rápidos.\n
     &#8226; IA avançada para análises mais profundas.\n
@@ -39,4 +39,5 @@
 
   <string name="watch_ad_and_reset_limit">Assista ao anúncio completo para redefinir o limite (sem recompensa se ignorado)</string>
   <string name="ad_not_available">Anúncio não disponível. Por favor, tente novamente mais tarde.</string>
+  <string name="or_label">ou</string>
 </resources>

--- a/feature/gpt/src/main/res/values-ru/strings.xml
+++ b/feature/gpt/src/main/res/values-ru/strings.xml
@@ -36,4 +36,6 @@
   <string name="trial_conditions">• Отменить в любой момент\n• Без оплаты во время бесплатного пробного периода\n• Эксклюзивные функции во время пробного периода</string>
   <string name="message_input_hint">Введите сообщение</string>
 
+  <string name="watch_ad_and_reset_limit">Посмотрите полную рекламу, чтобы сбросить лимит (без вознаграждения, если пропущено)</string>
+  <string name="ad_not_available">Реклама недоступна. Пожалуйста, попробуйте еще раз позже.</string>
 </resources>

--- a/feature/gpt/src/main/res/values-ru/strings.xml
+++ b/feature/gpt/src/main/res/values-ru/strings.xml
@@ -21,9 +21,9 @@
 
   <string name="qurangpt">QuranGPT</string>
   <string name="qurangpt_pro">QuranGPT Pro</string>
-  <string name="upgrade_to_premium">Обновитесь до \nQuranGPT Pro</string>
+  <string name="upgrade_to_premium">Обновитесь до Pro</string>
   <string name="premium_features_description">
-    Наслаждайтесь эксклюзивными премиум-функциями:\n\n
+    Наслаждайтесь эксклюзивными премиум-функциями:\n
     &#8226; Неограниченные ответы от QuranGPT.\n
     &#8226; Более быстрые ответы.\n
     &#8226; Продвинутый ИИ для более глубокого анализа.\n
@@ -38,4 +38,5 @@
 
   <string name="watch_ad_and_reset_limit">Посмотрите полную рекламу, чтобы сбросить лимит (без вознаграждения, если пропущено)</string>
   <string name="ad_not_available">Реклама недоступна. Пожалуйста, попробуйте еще раз позже.</string>
+  <string name="or_label">или</string>
 </resources>

--- a/feature/gpt/src/main/res/values-ru/strings.xml
+++ b/feature/gpt/src/main/res/values-ru/strings.xml
@@ -36,7 +36,7 @@
   <string name="trial_conditions">• Отменить в любой момент\n• Без оплаты во время бесплатного пробного периода\n• Эксклюзивные функции во время пробного периода</string>
   <string name="message_input_hint">Введите сообщение</string>
 
-  <string name="watch_ad_and_reset_limit">Посмотрите полную рекламу, чтобы сбросить лимит (без вознаграждения, если пропущено)</string>
+  <string name="watch_ad_and_reset_limit">Посмотрите полную рекламу, чтобы сбросить лимит</string>
   <string name="ad_not_available">Реклама недоступна. Пожалуйста, попробуйте еще раз позже.</string>
   <string name="or_label">или</string>
 </resources>

--- a/feature/gpt/src/main/res/values-sq/strings.xml
+++ b/feature/gpt/src/main/res/values-sq/strings.xml
@@ -23,9 +23,9 @@
   <string name="qurangpt">QuranGPT</string>
   <string name="qurangpt_pro">QuranGPT Pro</string>
 
-  <string name="upgrade_to_premium">Kaloni në \nQuranGPT Pro</string>
+  <string name="upgrade_to_premium">Kaloni në Pro</string>
   <string name="premium_features_description">
-    Shijoni veçoritë ekskluzive premium:\n\n
+    Shijoni veçoritë ekskluzive premium:\n
     &#8226; Përgjigje të pakufizuara nga QuranGPT.\n
     &#8226; Koha më e shpejtë e përgjigjes.\n
     &#8226; AI e avancuar për njohuri më të thella.\n
@@ -40,4 +40,5 @@
 
   <string name="watch_ad_and_reset_limit">Shikoni reklamën e plotë për të rivendosur kufirin (pa shpërblim nëse anashkalohet)</string>
   <string name="ad_not_available">Reklama nuk është e disponueshme. Ju lutemi provoni përsëri më vonë.</string>
+  <string name="or_label">ose</string>
 </resources>

--- a/feature/gpt/src/main/res/values-sq/strings.xml
+++ b/feature/gpt/src/main/res/values-sq/strings.xml
@@ -38,7 +38,7 @@
   <string name="trial_conditions">• Anulo në çdo kohë\n• Pa pagesa gjatë periudhës së provës falas\n• Veçori ekskluzive gjatë provës</string>
   <string name="message_input_hint">Shkruani mesazhin tuaj</string>
 
-  <string name="watch_ad_and_reset_limit">Shikoni reklamën e plotë për të rivendosur kufirin (pa shpërblim nëse anashkalohet)</string>
+  <string name="watch_ad_and_reset_limit">Shikoni reklamën e plotë për të rivendosur kufirin</string>
   <string name="ad_not_available">Reklama nuk është e disponueshme. Ju lutemi provoni përsëri më vonë.</string>
   <string name="or_label">ose</string>
 </resources>

--- a/feature/gpt/src/main/res/values-sq/strings.xml
+++ b/feature/gpt/src/main/res/values-sq/strings.xml
@@ -38,4 +38,6 @@
   <string name="trial_conditions">• Anulo në çdo kohë\n• Pa pagesa gjatë periudhës së provës falas\n• Veçori ekskluzive gjatë provës</string>
   <string name="message_input_hint">Shkruani mesazhin tuaj</string>
 
+  <string name="watch_ad_and_reset_limit">Shikoni reklamën e plotë për të rivendosur kufirin (pa shpërblim nëse anashkalohet)</string>
+  <string name="ad_not_available">Reklama nuk është e disponueshme. Ju lutemi provoni përsëri më vonë.</string>
 </resources>

--- a/feature/gpt/src/main/res/values-sr/strings.xml
+++ b/feature/gpt/src/main/res/values-sr/strings.xml
@@ -11,33 +11,34 @@
   <string name="taptargetview_fap_biblegpt_title">Ћаскајте са QuranGPT</string>
   <string name="taptargetview_fap_biblegpt_desc">Ваш лични асистент за Куран. Постављајте питања, истражујте стихове или затражите молитве.</string>
   <string name="taptargetview_fap_biblegpt_sura">Poglavlja</string>
-  <string name="taptargetview_fap_biblegpt_sura_desc">Istražite Kur\'an prema poglavljima i ajetima.</string>
-  <string name="taptargetview_fap_biblegpt_juz">Deo (Džuz)</string>
-  <string name="taptargetview_fap_biblegpt_juz_desc">Navigirajte kroz Kur\'an podeljen u 30 delova.</string>
-  <string name="taptargetview_fap_biblegpt_bookmark">Obeležja</string>
-  <string name="taptargetview_fap_biblegpt_bookmark_desc">Sačuvajte omiljene ajete za brz pristup.</string>
+  <string name="taptargetview_fap_biblegpt_sura_desc">Istražite Kur\'an према поглављима и ајетима.</string>
+  <string name="taptargetview_fap_biblegpt_juz">Deо (Džuz)</string>
+  <string name="taptargetview_fap_biblegpt_juz_desc">Navigirajte kroz Kur\'an подељен у 30 делова.</string>
+  <string name="taptargetview_fap_biblegpt_bookmark">Obeležја</string>
+  <string name="taptargetview_fap_biblegpt_bookmark_desc">Сачувајте омилjene ајете за брз приступ.</string>
   <string name="taptargetview_fap_biblegpt_search">Pretraga</string>
-  <string name="taptargetview_fap_biblegpt_search_desc">Brzo pronađite ajete ili teme u Kur\'anu.</string>
+  <string name="taptargetview_fap_biblegpt_search_desc">Брзо пронађите ајете или теме у Кур\'ану.</string>
 
 
   <string name="qurangpt">QuranGPT</string>
   <string name="qurangpt_pro">QuranGPT Pro</string>
 
-  <string name="upgrade_to_premium">Nadogradite na \nQuranGPT Pro</string>
+  <string name="upgrade_to_premium">Nadоградите на Pro</string>
   <string name="premium_features_description">
-    Uživajte u ekskluzivnim premium funkcijama:\n\n
-    &#8226; Neograničeni odgovori od QuranGPT.\n
-    &#8226; Brže vreme odgovora.\n
-    &#8226; Napredna AI za dublje uvide.\n
+    Уживајте у ексклузивним премиум функцијама:\n
+    &#8226; Неограничени одговори од QuranGPT.\n
+    &#8226; Брже време одговора.\n
+    &#8226; Напредна AI за дубље увиде.\n
 </string>
-  <string name="monthly_plan_text">Mesečno</string>
-  <string name="yearly_plan_text">Godišnje</string>
-  <string name="discount_badge_text">Uštedite 30%</string>
-  <string name="upgrade_now">Započnite 7-dnevno besplatno probno razdoblje</string>
-  <string name="no_thanks">Možda kasnije</string>
-  <string name="trial_conditions">• Otkažite u bilo kom trenutku\n• Nema troškova tokom besplatnog probnog perioda\n• Ekskluzivne funkcije tokom probnog perioda</string>
-  <string name="message_input_hint">Unesite poruku</string>
+  <string name="monthly_plan_text">Месечно</string>
+  <string name="yearly_plan_text">Годишње</string>
+  <string name="discount_badge_text">Уштедите 30%</string>
+  <string name="upgrade_now">Започните 7-дневно бесплатно пробно раздобље</string>
+  <string name="no_thanks">Можда касније</string>
+  <string name="trial_conditions">• Откажите у било ком тренутку\n• Нема трошкова током бесплатног пробног периода\n• Ексклузивне функције током пробног периода</string>
+  <string name="message_input_hint">Унесите поруку</string>
 
   <string name="watch_ad_and_reset_limit">Гледајте комплетну рекламу да бисте ресетовали границу (без награде ако је прескочено)</string>
   <string name="ad_not_available">Реклама није доступна. Покушајте поново касније.</string>
+  <string name="or_label">или</string>
 </resources>

--- a/feature/gpt/src/main/res/values-sr/strings.xml
+++ b/feature/gpt/src/main/res/values-sr/strings.xml
@@ -38,7 +38,7 @@
   <string name="trial_conditions">• Откажите у било ком тренутку\n• Нема трошкова током бесплатног пробног периода\n• Ексклузивне функције током пробног периода</string>
   <string name="message_input_hint">Унесите поруку</string>
 
-  <string name="watch_ad_and_reset_limit">Гледајте комплетну рекламу да бисте ресетовали границу (без награде ако је прескочено)</string>
+  <string name="watch_ad_and_reset_limit">Гледајте комплетну рекламу да бисте ресетовали границу</string>
   <string name="ad_not_available">Реклама није доступна. Покушајте поново касније.</string>
   <string name="or_label">или</string>
 </resources>

--- a/feature/gpt/src/main/res/values-sr/strings.xml
+++ b/feature/gpt/src/main/res/values-sr/strings.xml
@@ -38,4 +38,6 @@
   <string name="trial_conditions">• Otkažite u bilo kom trenutku\n• Nema troškova tokom besplatnog probnog perioda\n• Ekskluzivne funkcije tokom probnog perioda</string>
   <string name="message_input_hint">Unesite poruku</string>
 
+  <string name="watch_ad_and_reset_limit">Гледајте комплетну рекламу да бисте ресетовали границу (без награде ако је прескочено)</string>
+  <string name="ad_not_available">Реклама није доступна. Покушајте поново касније.</string>
 </resources>

--- a/feature/gpt/src/main/res/values-sv/strings.xml
+++ b/feature/gpt/src/main/res/values-sv/strings.xml
@@ -38,4 +38,6 @@
   <string name="trial_conditions">• Avbryt när som helst\n• Inga avgifter under gratis provperiod\n• Exklusiva funktioner under provperioden</string>
   <string name="message_input_hint">Skriv ditt meddelande</string>
 
+  <string name="watch_ad_and_reset_limit">Titta på hela annonsen för att återställa gränsen (ingen belöning om den hoppas över)</string>
+  <string name="ad_not_available">Annons inte tillgänglig. Försök igen senare.</string>
 </resources>

--- a/feature/gpt/src/main/res/values-sv/strings.xml
+++ b/feature/gpt/src/main/res/values-sv/strings.xml
@@ -38,7 +38,7 @@
   <string name="trial_conditions">• Avbryt när som helst\n• Inga avgifter under gratis provperiod\n• Exklusiva funktioner under provperioden</string>
   <string name="message_input_hint">Skriv ditt meddelande</string>
 
-  <string name="watch_ad_and_reset_limit">Titta på hela annonsen för att återställa gränsen (ingen belöning om den hoppas över)</string>
+  <string name="watch_ad_and_reset_limit">Titta på hela annonsen för att återställa gränsen</string>
   <string name="ad_not_available">Annons inte tillgänglig. Försök igen senare.</string>
   <string name="or_label">eller</string>
 </resources>

--- a/feature/gpt/src/main/res/values-sv/strings.xml
+++ b/feature/gpt/src/main/res/values-sv/strings.xml
@@ -23,9 +23,9 @@
   <string name="qurangpt">QuranGPT</string>
   <string name="qurangpt_pro">QuranGPT Pro</string>
 
-  <string name="upgrade_to_premium">Uppgradera till \nQuranGPT Pro</string>
+  <string name="upgrade_to_premium">Uppgradera till Pro</string>
   <string name="premium_features_description">
-    Njut av exklusiva premiumfunktioner:\n\n
+    Njut av exklusiva premiumfunktioner:\n
     &#8226; Obegränsade svar från QuranGPT.\n
     &#8226; Snabbare svarstider.\n
     &#8226; Avancerad AI för djupare insikter.\n
@@ -40,4 +40,5 @@
 
   <string name="watch_ad_and_reset_limit">Titta på hela annonsen för att återställa gränsen (ingen belöning om den hoppas över)</string>
   <string name="ad_not_available">Annons inte tillgänglig. Försök igen senare.</string>
+  <string name="or_label">eller</string>
 </resources>

--- a/feature/gpt/src/main/res/values-th/strings.xml
+++ b/feature/gpt/src/main/res/values-th/strings.xml
@@ -38,7 +38,7 @@
   <string name="trial_conditions">• ยกเลิกได้ทุกเมื่อ\n• ไม่มีค่าใช้จ่ายในช่วงทดลองใช้ฟรี\n• คุณสมบัติพิเศษระหว่างช่วงทดลอง</string>
   <string name="message_input_hint">พิมพ์ข้อความของคุณ</string>
 
-  <string name="watch_ad_and_reset_limit">ดูโฆษณาเต็มรูปแบบเพื่อรีเซ็ตขีดจำกัด (ไม่มีรางวัลหากข้าม)</string>
+  <string name="watch_ad_and_reset_limit">ดูโฆษณาเต็มรูปแบบเพื่อรีเซ็ตขีดจำกัด</string>
   <string name="ad_not_available">โฆษณาไม่พร้อมใช้งาน โปรดลองอีกครั้งในภายหลัง</string>
   <string name="or_label">หรือ</string>
 </resources>

--- a/feature/gpt/src/main/res/values-th/strings.xml
+++ b/feature/gpt/src/main/res/values-th/strings.xml
@@ -38,4 +38,6 @@
   <string name="trial_conditions">• ยกเลิกได้ทุกเมื่อ\n• ไม่มีค่าใช้จ่ายในช่วงทดลองใช้ฟรี\n• คุณสมบัติพิเศษระหว่างช่วงทดลอง</string>
   <string name="message_input_hint">พิมพ์ข้อความของคุณ</string>
 
+  <string name="watch_ad_and_reset_limit">ดูโฆษณาเต็มรูปแบบเพื่อรีเซ็ตขีดจำกัด (ไม่มีรางวัลหากข้าม)</string>
+  <string name="ad_not_available">โฆษณาไม่พร้อมใช้งาน โปรดลองอีกครั้งในภายหลัง</string>
 </resources>

--- a/feature/gpt/src/main/res/values-th/strings.xml
+++ b/feature/gpt/src/main/res/values-th/strings.xml
@@ -23,9 +23,9 @@
   <string name="qurangpt">QuranGPT</string>
   <string name="qurangpt_pro">QuranGPT Pro</string>
 
-  <string name="upgrade_to_premium">อัปเกรดเป็น \nQuranGPT Pro</string>
+  <string name="upgrade_to_premium">อัปเกรดเป็น Pro</string>
   <string name="premium_features_description">
-    เพลิดเพลินกับคุณสมบัติพรีเมียมสุดพิเศษ:\n\n
+    เพลิดเพลินกับคุณสมบัติพรีเมียมสุดพิเศษ:\n
     &#8226; คำตอบจาก QuranGPT ไม่จำกัด\n
     &#8226; เวลาตอบสนองที่เร็วขึ้น\n
     &#8226; AI ขั้นสูงสำหรับข้อมูลเชิงลึกที่ลึกซึ้งยิ่งขึ้น\n
@@ -40,4 +40,5 @@
 
   <string name="watch_ad_and_reset_limit">ดูโฆษณาเต็มรูปแบบเพื่อรีเซ็ตขีดจำกัด (ไม่มีรางวัลหากข้าม)</string>
   <string name="ad_not_available">โฆษณาไม่พร้อมใช้งาน โปรดลองอีกครั้งในภายหลัง</string>
+  <string name="or_label">หรือ</string>
 </resources>

--- a/feature/gpt/src/main/res/values-tr/strings.xml
+++ b/feature/gpt/src/main/res/values-tr/strings.xml
@@ -21,9 +21,9 @@
 
   <string name="qurangpt">QuranGPT</string>
   <string name="qurangpt_pro">QuranGPT Pro</string>
-  <string name="upgrade_to_premium">QuranGPT Pro’ya \nGeçiş Yapın</string>
+  <string name="upgrade_to_premium">Pro’ya Geçiş Yapın</string>
   <string name="premium_features_description">
-    Özel premium özelliklerin tadını çıkarın:\n\n
+    Özel premium özelliklerin tadını çıkarın:\n
     &#8226; Sınırsız QuranGPT yanıtı.\n
     &#8226; Daha hızlı yanıt süreleri.\n
     &#8226; Daha derin içgörüler için gelişmiş yapay zeka.\n
@@ -38,4 +38,5 @@
 
   <string name="watch_ad_and_reset_limit">Sınırı sıfırlamak için tam reklamı izleyin (atlanırsa ödül yok)</string>
   <string name="ad_not_available">Reklam mevcut değil. Lütfen daha sonra tekrar deneyin.</string>
+  <string name="or_label">veya</string>
 </resources>

--- a/feature/gpt/src/main/res/values-tr/strings.xml
+++ b/feature/gpt/src/main/res/values-tr/strings.xml
@@ -36,4 +36,6 @@
   <string name="trial_conditions">• İstediğiniz zaman iptal edin\n• Ücretsiz deneme süresi boyunca hiçbir ücret yok\n• Deneme sırasında özel özellikler</string>
   <string name="message_input_hint">Mesajınızı yazın</string>
 
+  <string name="watch_ad_and_reset_limit">Sınırı sıfırlamak için tam reklamı izleyin (atlanırsa ödül yok)</string>
+  <string name="ad_not_available">Reklam mevcut değil. Lütfen daha sonra tekrar deneyin.</string>
 </resources>

--- a/feature/gpt/src/main/res/values-tr/strings.xml
+++ b/feature/gpt/src/main/res/values-tr/strings.xml
@@ -36,7 +36,7 @@
   <string name="trial_conditions">• İstediğiniz zaman iptal edin\n• Ücretsiz deneme süresi boyunca hiçbir ücret yok\n• Deneme sırasında özel özellikler</string>
   <string name="message_input_hint">Mesajınızı yazın</string>
 
-  <string name="watch_ad_and_reset_limit">Sınırı sıfırlamak için tam reklamı izleyin (atlanırsa ödül yok)</string>
+  <string name="watch_ad_and_reset_limit">Sınırı sıfırlamak için tam reklamı izleyin</string>
   <string name="ad_not_available">Reklam mevcut değil. Lütfen daha sonra tekrar deneyin.</string>
   <string name="or_label">veya</string>
 </resources>

--- a/feature/gpt/src/main/res/values-ug/strings.xml
+++ b/feature/gpt/src/main/res/values-ug/strings.xml
@@ -37,7 +37,7 @@
   <string name="trial_conditions">• ھەر قانداق ۋاقىتتا بىكار قىلىش\n• ھەقسىز سىناش مەزگىلىدە ھەچقانداق ھەق تولانمايدۇ\n• سىناش مەزگىلىدە ئالاھىدە ئىقتىدارلار</string>
   <string name="message_input_hint">ئۇچۇرىڭىزنى يېزىڭ</string>
 
-  <string name="watch_ad_and_reset_limit">چەكنى ئەسلىگە كەلتۈرۈش ئۈچۈن تولۇق ئېلاننى كۆرۈڭ (ئاتلاپ ئۆتۈلسە ھېچقانداق مۇكاپات يوق)</string>
+  <string name="watch_ad_and_reset_limit">چېكلەشنى ئەسلىگە كەلتۈرۈش ئۈچۈن تولۇق ئېلاننى كۆرۈڭ</string>
   <string name="ad_not_available">ئېلاننى ئىشلەتكىلى بولمايدۇ. كېيىن قايتا سىناڭ.</string>
   <string name="or_label">ياكى</string>
 </resources>

--- a/feature/gpt/src/main/res/values-ug/strings.xml
+++ b/feature/gpt/src/main/res/values-ug/strings.xml
@@ -22,9 +22,9 @@
   <string name="qurangpt">قۇرئانGPT</string>
   <string name="qurangpt_pro">قۇرئانGPT Pro</string>
 
-  <string name="upgrade_to_premium">QuranGPT Pro نى ئۆستۈرۈڭ</string>
+  <string name="upgrade_to_premium">Pro نى ئۆستۈرۈڭ</string>
   <string name="premium_features_description">
-    مەخسۇس ئالاھىدە مۇلازىمەتتىن ھوزۇرلىنىڭ:\n\n
+    مەخسۇس ئالاھىدە مۇلازىمەتتىن ھوزۇرلىنىڭ:\n
     &#8226; چەكلىمىسىز QuranGPT جاۋابلىرى.\n
     &#8226; تېز جاۋاب ۋاقتى.\n
     &#8226; ئېنىق ئانالىز ئۈچۈن ئىلغار AI.\n
@@ -39,4 +39,5 @@
 
   <string name="watch_ad_and_reset_limit">چەكنى ئەسلىگە كەلتۈرۈش ئۈچۈن تولۇق ئېلاننى كۆرۈڭ (ئاتلاپ ئۆتۈلسە ھېچقانداق مۇكاپات يوق)</string>
   <string name="ad_not_available">ئېلاننى ئىشلەتكىلى بولمايدۇ. كېيىن قايتا سىناڭ.</string>
+  <string name="or_label">ياكى</string>
 </resources>

--- a/feature/gpt/src/main/res/values-ug/strings.xml
+++ b/feature/gpt/src/main/res/values-ug/strings.xml
@@ -37,4 +37,6 @@
   <string name="trial_conditions">• ھەر قانداق ۋاقىتتا بىكار قىلىش\n• ھەقسىز سىناش مەزگىلىدە ھەچقانداق ھەق تولانمايدۇ\n• سىناش مەزگىلىدە ئالاھىدە ئىقتىدارلار</string>
   <string name="message_input_hint">ئۇچۇرىڭىزنى يېزىڭ</string>
 
+  <string name="watch_ad_and_reset_limit">چەكنى ئەسلىگە كەلتۈرۈش ئۈچۈن تولۇق ئېلاننى كۆرۈڭ (ئاتلاپ ئۆتۈلسە ھېچقانداق مۇكاپات يوق)</string>
+  <string name="ad_not_available">ئېلاننى ئىشلەتكىلى بولمايدۇ. كېيىن قايتا سىناڭ.</string>
 </resources>

--- a/feature/gpt/src/main/res/values-uk/strings.xml
+++ b/feature/gpt/src/main/res/values-uk/strings.xml
@@ -37,4 +37,6 @@
   <string name="trial_conditions">• Скасуйте в будь-який час\n• Немає платежів під час безкоштовного пробного періоду\n• Ексклюзивні функції під час пробного періоду</string>
   <string name="message_input_hint">Введіть повідомлення</string>
 
+  <string name="watch_ad_and_reset_limit">Перегляньте повну рекламу, щоб скинути ліміт (без винагороди, якщо пропустите)</string>
+  <string name="ad_not_available">Реклама недоступна. Будь ласка, спробуйте пізніше.</string>
 </resources>

--- a/feature/gpt/src/main/res/values-uk/strings.xml
+++ b/feature/gpt/src/main/res/values-uk/strings.xml
@@ -22,9 +22,9 @@
   <string name="qurangpt">QuranGPT</string>
   <string name="qurangpt_pro">QuranGPT Pro</string>
 
-  <string name="upgrade_to_premium">Оновіть до \nQuranGPT Pro</string>
+  <string name="upgrade_to_premium">Оновіть до Pro</string>
   <string name="premium_features_description">
-    Насолоджуйтесь ексклюзивними преміум-функціями:\n\n
+    Насолоджуйтесь ексклюзивними преміум-функціями:\n
     &#8226; Необмежені відповіді QuranGPT.\n
     &#8226; Швидший час відповіді.\n
     &#8226; Розширений ШІ для глибших інсайтів.\n
@@ -39,4 +39,5 @@
 
   <string name="watch_ad_and_reset_limit">Перегляньте повну рекламу, щоб скинути ліміт (без винагороди, якщо пропустите)</string>
   <string name="ad_not_available">Реклама недоступна. Будь ласка, спробуйте пізніше.</string>
+  <string name="or_label">або</string>
 </resources>

--- a/feature/gpt/src/main/res/values-uk/strings.xml
+++ b/feature/gpt/src/main/res/values-uk/strings.xml
@@ -37,7 +37,7 @@
   <string name="trial_conditions">• Скасуйте в будь-який час\n• Немає платежів під час безкоштовного пробного періоду\n• Ексклюзивні функції під час пробного періоду</string>
   <string name="message_input_hint">Введіть повідомлення</string>
 
-  <string name="watch_ad_and_reset_limit">Перегляньте повну рекламу, щоб скинути ліміт (без винагороди, якщо пропустите)</string>
+  <string name="watch_ad_and_reset_limit">Перегляньте повну рекламу, щоб скинути ліміт</string>
   <string name="ad_not_available">Реклама недоступна. Будь ласка, спробуйте пізніше.</string>
   <string name="or_label">або</string>
 </resources>

--- a/feature/gpt/src/main/res/values-uz/strings.xml
+++ b/feature/gpt/src/main/res/values-uz/strings.xml
@@ -36,7 +36,7 @@
   <string name="trial_conditions">• Istalgan vaqtda bekor qiling\n• Bepul sinov davrida hech qanday to‘lov yo‘q\n• Sinov davrida eksklyuziv xususiyatlar</string>
   <string name="message_input_hint">Xabaringizni kiriting</string>
 
-  <string name="watch_ad_and_reset_limit">Cheklovni tiklash uchun to\'liq reklamani tomosha qiling (o\'tkazib yuborilsa mukofot yo\'q)</string>
+  <string name="watch_ad_and_reset_limit">Cheklovni tiklash uchun to\'liq reklamani tomosha qiling</string>
   <string name="ad_not_available">Reklama mavjud emas. Keyinroq qayta urinib ko\'ring.</string>
   <string name="or_label">yoki</string>
 </resources>

--- a/feature/gpt/src/main/res/values-uz/strings.xml
+++ b/feature/gpt/src/main/res/values-uz/strings.xml
@@ -21,9 +21,9 @@
 
   <string name="qurangpt">QuranGPT</string>
   <string name="qurangpt_pro">QuranGPT Pro</string>
-  <string name="upgrade_to_premium">QuranGPT Pro ga \nYangilang</string>
+  <string name="upgrade_to_premium">Pro ga Yangilang</string>
   <string name="premium_features_description">
-    Eksklyuziv premium xususiyatlardan bahramand bo‘ling:\n\n
+    Eksklyuziv premium xususiyatlardan bahramand bo‘ling:\n
     &#8226; Cheksiz QuranGPT javoblari.\n
     &#8226; Tezroq javob vaqti.\n
     &#8226; Chuqurroq tushunchalar uchun ilg‘or AI.\n
@@ -38,4 +38,5 @@
 
   <string name="watch_ad_and_reset_limit">Cheklovni tiklash uchun to\'liq reklamani tomosha qiling (o\'tkazib yuborilsa mukofot yo\'q)</string>
   <string name="ad_not_available">Reklama mavjud emas. Keyinroq qayta urinib ko\'ring.</string>
+  <string name="or_label">yoki</string>
 </resources>

--- a/feature/gpt/src/main/res/values-uz/strings.xml
+++ b/feature/gpt/src/main/res/values-uz/strings.xml
@@ -36,4 +36,6 @@
   <string name="trial_conditions">• Istalgan vaqtda bekor qiling\n• Bepul sinov davrida hech qanday to‘lov yo‘q\n• Sinov davrida eksklyuziv xususiyatlar</string>
   <string name="message_input_hint">Xabaringizni kiriting</string>
 
+  <string name="watch_ad_and_reset_limit">Cheklovni tiklash uchun to\'liq reklamani tomosha qiling (o\'tkazib yuborilsa mukofot yo\'q)</string>
+  <string name="ad_not_available">Reklama mavjud emas. Keyinroq qayta urinib ko\'ring.</string>
 </resources>

--- a/feature/gpt/src/main/res/values-vi/strings.xml
+++ b/feature/gpt/src/main/res/values-vi/strings.xml
@@ -37,4 +37,6 @@
   <string name="trial_conditions">• Hủy bất kỳ lúc nào\n• Không có phí trong thời gian dùng thử miễn phí\n• Tính năng độc quyền trong thời gian dùng thử</string>
   <string name="message_input_hint">Nhập tin nhắn của bạn</string>
 
+  <string name="watch_ad_and_reset_limit">Xem toàn bộ quảng cáo để đặt lại giới hạn (không có phần thưởng nếu bỏ qua)</string>
+  <string name="ad_not_available">Quảng cáo không có sẵn. Vui lòng thử lại sau.</string>
 </resources>

--- a/feature/gpt/src/main/res/values-vi/strings.xml
+++ b/feature/gpt/src/main/res/values-vi/strings.xml
@@ -37,7 +37,7 @@
   <string name="trial_conditions">• Hủy bất kỳ lúc nào\n• Không có phí trong thời gian dùng thử miễn phí\n• Tính năng độc quyền trong thời gian dùng thử</string>
   <string name="message_input_hint">Nhập tin nhắn của bạn</string>
 
-  <string name="watch_ad_and_reset_limit">Xem toàn bộ quảng cáo để đặt lại giới hạn (không có phần thưởng nếu bỏ qua)</string>
+  <string name="watch_ad_and_reset_limit">Xem toàn bộ quảng cáo để đặt lại giới hạn</string>
   <string name="ad_not_available">Quảng cáo không có sẵn. Vui lòng thử lại sau.</string>
   <string name="or_label">hoặc</string>
 </resources>

--- a/feature/gpt/src/main/res/values-vi/strings.xml
+++ b/feature/gpt/src/main/res/values-vi/strings.xml
@@ -22,9 +22,9 @@
 
   <string name="qurangpt">QuranGPT</string>
   <string name="qurangpt_pro">QuranGPT Pro</string>
-  <string name="upgrade_to_premium">Nâng cấp lên \nQuranGPT Pro</string>
+  <string name="upgrade_to_premium">Nâng cấp lên Pro</string>
   <string name="premium_features_description">
-    Tận hưởng các tính năng cao cấp độc quyền:\n\n
+    Tận hưởng các tính năng cao cấp độc quyền:\n
     &#8226; Trả lời không giới hạn từ QuranGPT.\n
     &#8226; Thời gian phản hồi nhanh hơn.\n
     &#8226; AI tiên tiến để hiểu sâu hơn.\n
@@ -39,4 +39,5 @@
 
   <string name="watch_ad_and_reset_limit">Xem toàn bộ quảng cáo để đặt lại giới hạn (không có phần thưởng nếu bỏ qua)</string>
   <string name="ad_not_available">Quảng cáo không có sẵn. Vui lòng thử lại sau.</string>
+  <string name="or_label">hoặc</string>
 </resources>

--- a/feature/gpt/src/main/res/values-zh/strings.xml
+++ b/feature/gpt/src/main/res/values-zh/strings.xml
@@ -21,9 +21,9 @@
 
   <string name="qurangpt">QuranGPT</string>
   <string name="qurangpt_pro">QuranGPT Pro</string>
-  <string name="upgrade_to_premium">升级到 \nQuranGPT Pro</string>
+  <string name="upgrade_to_premium">升级到 Pro</string>
   <string name="premium_features_description">
-    享受独家高级功能：\n\n
+    享受独家高级功能：\n
     &#8226; 无限制的 QuranGPT 答复。\n
     &#8226; 更快的响应时间。\n
     &#8226; 先进的 AI 提供更深入的见解。\n
@@ -38,4 +38,5 @@
 
   <string name="watch_ad_and_reset_limit">观看完整的广告以重置限制（如果跳过，则没有奖励）</string>
   <string name="ad_not_available">广告不可用。请稍后再试。</string>
+  <string name="or_label">或</string>
 </resources>

--- a/feature/gpt/src/main/res/values-zh/strings.xml
+++ b/feature/gpt/src/main/res/values-zh/strings.xml
@@ -36,4 +36,6 @@
   <string name="trial_conditions">• 随时取消\n• 免费试用期间无费用\n• 试用期间专属功能</string>
   <string name="message_input_hint">输入您的消息</string>
 
+  <string name="watch_ad_and_reset_limit">观看完整的广告以重置限制（如果跳过，则没有奖励）</string>
+  <string name="ad_not_available">广告不可用。请稍后再试。</string>
 </resources>

--- a/feature/gpt/src/main/res/values-zh/strings.xml
+++ b/feature/gpt/src/main/res/values-zh/strings.xml
@@ -36,7 +36,7 @@
   <string name="trial_conditions">• 随时取消\n• 免费试用期间无费用\n• 试用期间专属功能</string>
   <string name="message_input_hint">输入您的消息</string>
 
-  <string name="watch_ad_and_reset_limit">观看完整的广告以重置限制（如果跳过，则没有奖励）</string>
+  <string name="watch_ad_and_reset_limit">观看完整广告以重置限制</string>
   <string name="ad_not_available">广告不可用。请稍后再试。</string>
   <string name="or_label">或</string>
 </resources>

--- a/feature/gpt/src/main/res/values/strings.xml
+++ b/feature/gpt/src/main/res/values/strings.xml
@@ -26,9 +26,9 @@ You\'ve reached your daily limit. Start your 3-day free trial for unlimited acce
   <string name="qurangpt_pro">QuranGPT Pro</string>
 
   <!-- res/values/strings.xml -->
-  <string name="upgrade_to_premium">Upgrade to \nQuranGPT Pro</string>
+  <string name="upgrade_to_premium">Upgrade to Pro</string>
   <string name="premium_features_description">
-    Enjoy exclusive premium features:\n\n
+    Enjoy exclusive premium features:\n
     &#8226; Unlimited QuranGPT answers.\n
     &#8226; Faster response times.\n
     &#8226; Advanced AI for deeper insights.\n
@@ -43,4 +43,5 @@ You\'ve reached your daily limit. Start your 3-day free trial for unlimited acce
   <string name="trial_conditions">• Cancel anytime\n• No charges during free trial\n• Exclusive features during trial</string>
   <string name="message_input_hint">Type your message</string>
   <string name="admob_banner_id" translatable="false">ca-app-pub-8655759847032068/7379234820</string>
+  <string name="or_label">or</string>
 </resources>

--- a/feature/gpt/src/main/res/values/strings.xml
+++ b/feature/gpt/src/main/res/values/strings.xml
@@ -37,7 +37,7 @@ You\'ve reached your daily limit. Start your 3-day free trial for unlimited acce
   <string name="yearly_plan_text">Yearly</string>
   <string name="discount_badge_text">Save 30%</string>
   <string name="upgrade_now">Start 7 day free trial</string>
-  <string name="watch_ad_and_reset_limit">Watch the full ad to reset the limit (no reward if skipped)</string>
+  <string name="watch_ad_and_reset_limit">Watch the full ad to reset the limit</string>
   <string name="ad_not_available">Ad not available. Please try again later.</string>
   <string name="no_thanks">Maybe later</string>
   <string name="trial_conditions">• Cancel anytime\n• No charges during free trial\n• Exclusive features during trial</string>

--- a/feature/gpt/src/main/res/values/strings.xml
+++ b/feature/gpt/src/main/res/values/strings.xml
@@ -37,7 +37,7 @@ You\'ve reached your daily limit. Start your 3-day free trial for unlimited acce
   <string name="yearly_plan_text">Yearly</string>
   <string name="discount_badge_text">Save 30%</string>
   <string name="upgrade_now">Start 7 day free trial</string>
-  <string name="watch_ad_and_reset_limit">Watch ad and reset limit</string>
+  <string name="watch_ad_and_reset_limit">Watch the full ad to reset the limit (no reward if skipped)</string>
   <string name="ad_not_available">Ad not available. Please try again later.</string>
   <string name="no_thanks">Maybe later</string>
   <string name="trial_conditions">• Cancel anytime\n• No charges during free trial\n• Exclusive features during trial</string>


### PR DESCRIPTION
## Summary
- require full ad viewing to reset limit
- localize ad availability message across supported languages

## Testing
- `./gradlew :feature:gpt:test` *(fails: Unrecognized VM option 'MaxPermSize=512m')*


------
https://chatgpt.com/codex/tasks/task_b_68b41c3bf9dc832ab3ac7611ed750871